### PR TITLE
Upgrade Selenium.WebDriver.ChromeDriver package to v83.0.4103.3900

### DIFF
--- a/Lombiq.Tests.UI.csproj
+++ b/Lombiq.Tests.UI.csproj
@@ -33,7 +33,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="Selenium.Axe" Version="1.5.1" />
     <PackageReference Include="Selenium.WebDriver" Version="3.141.0" />
-    <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="81.0.4044.6900" />
+    <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="83.0.4103.3900" />
     <PackageReference Include="Selenium.WebDriver.GeckoDriver" Version="0.26.0.1" />
     <PackageReference Include="Selenium.WebDriver.IEDriver" Version="3.150.1" />
     <PackageReference Include="Selenium.WebDriver.MSEdgeDriver" Version="81.0.410" />


### PR DESCRIPTION
Current version of ChromeDriver is not compatible with latest Chrome v83. All tests are failed to run.