### PR TITLE
SNOW-72: Restoring the Atata 1.x style default element lookup behavior

### DIFF
--- a/Lombiq.Tests.UI/Extensions/FormUITestContextExtensions.cs
+++ b/Lombiq.Tests.UI/Extensions/FormUITestContextExtensions.cs
@@ -238,7 +238,7 @@ public static class FormUITestContextExtensions
     /// Finds the first submit button and clicks on it reliably.
     /// </summary>
     public static Task ClickReliablyOnSubmitAsync(this UITestContext context) =>
-        context.ClickReliablyOnAsync(By.CssSelector("button[type='submit']"));
+        context.ClickReliablyOnAsync(By.XPath("//button[@type='submit' and not(ancestor::form[@action='/Users/LogOff'])]"));
 
     /// <summary>
     /// Finds the "Add New" button.

--- a/Lombiq.Tests.UI/Extensions/NavigationUITestContextExtensions.cs
+++ b/Lombiq.Tests.UI/Extensions/NavigationUITestContextExtensions.cs
@@ -207,7 +207,7 @@ public static class NavigationUITestContextExtensions
     private static async Task SetFieldDropdownByIndexAsync(UITestContext context, string baseSelector, int index)
     {
         var byItem = By.CssSelector(FormattableString.Invariant(
-            $"{baseSelector} .multiselect__element:nth-child({index + 1}) .multiselect__option"));
+            $"{baseSelector} .multiselect__element:nth-child({index + 1}) .multiselect__option")).Visible();
 
         while (!context.Exists(byItem.Safely()))
         {

--- a/Lombiq.Tests.UI/Services/AtataFactory.cs
+++ b/Lombiq.Tests.UI/Services/AtataFactory.cs
@@ -22,6 +22,10 @@ public static class AtataFactory
     {
         AtataContext.ModeOfCurrent = AtataContextModeOfCurrent.AsyncLocal;
 
+        // Since Atata 2.0 the default visibility option is Visibility.Any, these lines restore it to the 1.x behavior.
+        AtataContext.GlobalConfiguration.UseDefaultControlVisibility(Visibility.Visible);
+        SearchOptions.DefaultVisibility = Visibility.Visible;
+
         var timeoutConfiguration = configuration.TimeoutConfiguration;
         var browserConfiguration = configuration.BrowserConfiguration;
 


### PR DESCRIPTION
[SNOW-72](https://lombiq.atlassian.net/browse/SNOW-72)

only find visible elements