### PR TITLE
OSOE-628: Migrate RestEase usage to Refit in Lombiq.OrchardCoreApiClient

### DIFF
--- a/Lombiq.Tests.UI/Extensions/ShortcutsUITestContextExtensions.cs
+++ b/Lombiq.Tests.UI/Extensions/ShortcutsUITestContextExtensions.cs
@@ -1,4 +1,3 @@
-using Atata;
 using Lombiq.HelpfulLibraries.OrchardCore.Mvc;
 using Lombiq.Tests.UI.Constants;
 using Lombiq.Tests.UI.Exceptions;
@@ -32,7 +31,7 @@ using OrchardCore.Workflows.Http.Controllers;
 using OrchardCore.Workflows.Http.Models;
 using OrchardCore.Workflows.Models;
 using OrchardCore.Workflows.Services;
-using RestEase;
+using Refit;
 using Shouldly;
 using System;
 using System.Collections.Concurrent;
@@ -414,7 +413,7 @@ public static class ShortcutsUITestContextExtensions
                     BaseAddress = context.Scope.BaseUri,
                 };
 
-                return RestClient.For<IShortcutsApi>(httpClient);
+                return RestService.For<IShortcutsApi>(httpClient);
             });
 
     [SuppressMessage(

--- a/Lombiq.Tests.UI/Extensions/ShortcutsUITestContextExtensions.cs
+++ b/Lombiq.Tests.UI/Extensions/ShortcutsUITestContextExtensions.cs
@@ -414,7 +414,7 @@ public static class ShortcutsUITestContextExtensions
                     BaseAddress = context.Scope.BaseUri,
                 };
 
-                return RefitHelper.WithNewtonsoft<IShortcutsApi>(httpClient);
+                return RefitHelper.WithNewtonsoftJson<IShortcutsApi>(httpClient);
             });
 
     /// <summary>

--- a/Lombiq.Tests.UI/Extensions/ShortcutsUITestContextExtensions.cs
+++ b/Lombiq.Tests.UI/Extensions/ShortcutsUITestContextExtensions.cs
@@ -422,7 +422,7 @@ public static class ShortcutsUITestContextExtensions
         Justification = "Just maps to controller actions.")]
     public interface IShortcutsApi
     {
-        [Get("api/ApplicationInfo")]
+        [Get("/api/ApplicationInfo")]
         Task<ApplicationInfo> GetApplicationInfoFromApiAsync();
     }
 

--- a/Lombiq.Tests.UI/Extensions/ShortcutsUITestContextExtensions.cs
+++ b/Lombiq.Tests.UI/Extensions/ShortcutsUITestContextExtensions.cs
@@ -416,12 +416,14 @@ public static class ShortcutsUITestContextExtensions
                 return RestService.For<IShortcutsApi>(httpClient);
             });
 
-    [SuppressMessage(
-        "StyleCop.CSharp.DocumentationRules",
-        "SA1600:Elements should be documented",
-        Justification = "Just maps to controller actions.")]
+    /// <summary>
+    /// A client interface for <c>Lombiq.Tests.UI.Shortcuts</c> web APIs.
+    /// </summary>
     public interface IShortcutsApi
     {
+        /// <summary>
+        /// Sends a web request to <see cref="ApplicationInfoController.Get"/> endpoint.
+        /// </summary>
         [Get("/api/ApplicationInfo")]
         Task<ApplicationInfo> GetApplicationInfoFromApiAsync();
     }

--- a/Lombiq.Tests.UI/Extensions/ShortcutsUITestContextExtensions.cs
+++ b/Lombiq.Tests.UI/Extensions/ShortcutsUITestContextExtensions.cs
@@ -1,4 +1,5 @@
 using Lombiq.HelpfulLibraries.OrchardCore.Mvc;
+using Lombiq.HelpfulLibraries.Refit.Helpers;
 using Lombiq.Tests.UI.Constants;
 using Lombiq.Tests.UI.Exceptions;
 using Lombiq.Tests.UI.Pages;
@@ -413,7 +414,7 @@ public static class ShortcutsUITestContextExtensions
                     BaseAddress = context.Scope.BaseUri,
                 };
 
-                return RestService.For<IShortcutsApi>(httpClient);
+                return RefitHelper.WithNewtonsoft<IShortcutsApi>(httpClient);
             });
 
     /// <summary>

--- a/Lombiq.Tests.UI/Extensions/ShortcutsUITestContextExtensions.cs
+++ b/Lombiq.Tests.UI/Extensions/ShortcutsUITestContextExtensions.cs
@@ -11,6 +11,7 @@ using Microsoft.Extensions.Logging;
 using OpenQA.Selenium;
 using OrchardCore.Abstractions.Setup;
 using OrchardCore.Admin;
+using OrchardCore.Data;
 using OrchardCore.DisplayManagement.Extensions;
 using OrchardCore.Entities;
 using OrchardCore.Environment.Extensions;
@@ -36,7 +37,6 @@ using Shouldly;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
 using System.Net.Http;
@@ -479,7 +479,7 @@ public static class ShortcutsUITestContextExtensions
     {
         setupParameters ??= new OrchardCoreSetupParameters(context);
         var databaseProvider = setupParameters.DatabaseProvider == OrchardCoreSetupPage.DatabaseType.SqlServer
-            ? OrchardCore.Data.DatabaseProviderValue.SqlConnection
+            ? DatabaseProviderValue.SqlConnection
             : setupParameters.DatabaseProvider.ToString();
 
         await context.Application.UsingScopeAsync(

--- a/Lombiq.Tests.UI/Lombiq.Tests.UI.csproj
+++ b/Lombiq.Tests.UI/Lombiq.Tests.UI.csproj
@@ -93,7 +93,7 @@
     <PackageReference Include="Lombiq.Tests" Version="2.2.0" />
     <PackageReference Include="Lombiq.HelpfulLibraries.Cli" Version="5.1.1" />
     <PackageReference Include="Lombiq.HelpfulLibraries.OrchardCore" Version="5.1.1" />
-    <PackageReference Include="Lombiq.HelpfulLibraries.Refit" Version="5.1.1" />
+    <PackageReference Include="Lombiq.HelpfulLibraries.Refit" Version="5.1.3-alpha.1.osoe-628" />
     <PackageReference Include="Lombiq.Npm.Targets" Version="1.3.0" />
   </ItemGroup>
 

--- a/Lombiq.Tests.UI/Lombiq.Tests.UI.csproj
+++ b/Lombiq.Tests.UI/Lombiq.Tests.UI.csproj
@@ -83,6 +83,7 @@
     <ProjectReference Include="..\..\Lombiq.Tests\Lombiq.Tests.csproj" />
     <ProjectReference Include="..\..\..\src\Libraries\Lombiq.HelpfulLibraries\Lombiq.HelpfulLibraries.Cli\Lombiq.HelpfulLibraries.Cli.csproj" />
     <ProjectReference Include="..\..\..\src\Libraries\Lombiq.HelpfulLibraries\Lombiq.HelpfulLibraries.OrchardCore\Lombiq.HelpfulLibraries.OrchardCore.csproj" />
+    <ProjectReference Include="..\..\..\src\Libraries\Lombiq.HelpfulLibraries\Lombiq.HelpfulLibraries.Refit\Lombiq.HelpfulLibraries.Refit.csproj" />
   </ItemGroup>
 
   <Import Condition="'$(NuGetBuild)' != 'true'" Project="..\..\..\src\Utilities\Lombiq.Npm.Targets\Lombiq.Npm.Targets.props" />
@@ -92,6 +93,7 @@
     <PackageReference Include="Lombiq.Tests" Version="2.2.0" />
     <PackageReference Include="Lombiq.HelpfulLibraries.Cli" Version="5.1.1" />
     <PackageReference Include="Lombiq.HelpfulLibraries.OrchardCore" Version="5.1.1" />
+    <PackageReference Include="Lombiq.HelpfulLibraries.Refit" Version="5.1.1" />
     <PackageReference Include="Lombiq.Npm.Targets" Version="1.3.0" />
   </ItemGroup>
 

--- a/Lombiq.Tests.UI/Lombiq.Tests.UI.csproj
+++ b/Lombiq.Tests.UI/Lombiq.Tests.UI.csproj
@@ -66,6 +66,7 @@
     <PackageReference Include="OrchardCore.Logging.NLog" Version="1.5.0" />
     <PackageReference Include="OrchardCore.Abstractions" Version="1.5.0" />
     <PackageReference Include="OrchardCore.Recipes.Core" Version="1.5.0" />
+    <PackageReference Include="Refit.HttpClientFactory" Version="6.3.2" />
     <PackageReference Include="Selenium.Axe" Version="4.0.5" />
     <PackageReference Include="Shouldly" Version="4.1.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
@@ -82,7 +83,6 @@
     <ProjectReference Include="..\..\Lombiq.Tests\Lombiq.Tests.csproj" />
     <ProjectReference Include="..\..\..\src\Libraries\Lombiq.HelpfulLibraries\Lombiq.HelpfulLibraries.Cli\Lombiq.HelpfulLibraries.Cli.csproj" />
     <ProjectReference Include="..\..\..\src\Libraries\Lombiq.HelpfulLibraries\Lombiq.HelpfulLibraries.OrchardCore\Lombiq.HelpfulLibraries.OrchardCore.csproj" />
-    <ProjectReference Include="..\..\..\src\Libraries\Lombiq.HelpfulLibraries\Lombiq.HelpfulLibraries.RestEase\Lombiq.HelpfulLibraries.RestEase.csproj" />
   </ItemGroup>
 
   <Import Condition="'$(NuGetBuild)' != 'true'" Project="..\..\..\src\Utilities\Lombiq.Npm.Targets\Lombiq.Npm.Targets.props" />
@@ -92,7 +92,6 @@
     <PackageReference Include="Lombiq.Tests" Version="2.2.0" />
     <PackageReference Include="Lombiq.HelpfulLibraries.Cli" Version="5.1.1" />
     <PackageReference Include="Lombiq.HelpfulLibraries.OrchardCore" Version="5.1.1" />
-    <PackageReference Include="Lombiq.HelpfulLibraries.RestEase" Version="5.1.1" />
     <PackageReference Include="Lombiq.Npm.Targets" Version="1.3.0" />
   </ItemGroup>
 


### PR DESCRIPTION
[OSOE-628](https://lombiq.atlassian.net/browse/OSOE-628)

Fixes #280.

[OSOE-628]: https://lombiq.atlassian.net/browse/OSOE-628?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ