### PR TITLE
OSOE-629: Adding FillInCodeMirrorEditorWithRetriesAsync() and SetTextContentWithScript(), renaming ChangeCurrentTenantToDefault(), using current tenant in shortcuts

### DIFF
--- a/Lombiq.Tests.UI.Samples/Tests/TenantTests.cs
+++ b/Lombiq.Tests.UI.Samples/Tests/TenantTests.cs
@@ -55,7 +55,7 @@ public class TenantTests : UITestBase
                 (await context.GetCurrentUserNameAsync()).ShouldBe(tenantAdminName);
                 context.GetCurrentUri().AbsolutePath.ShouldStartWith($"/{TestTenantUrlPrefix}");
 
-                context.ChangeCurrentTenantToDefault();
+                context.SwitchCurrentTenantToDefault();
                 (await context.GetCurrentUserNameAsync()).ShouldBe(DefaultUser.UserName);
                 context.GetCurrentUri().AbsolutePath.ShouldNotStartWith($"/{TestTenantUrlPrefix}");
             },

--- a/Lombiq.Tests.UI/Extensions/FormUITestContextExtensions.cs
+++ b/Lombiq.Tests.UI/Extensions/FormUITestContextExtensions.cs
@@ -77,7 +77,7 @@ public static class FormUITestContextExtensions
     }
 
     /// <summary>
-    /// Uses Javascript to reinitialize the given field's EasyMDE instance and then access the internal CodeMirror
+    /// Uses JavaScript to reinitialize the given field's EasyMDE instance and then access the internal CodeMirror
     /// editor to programmatically change the value. This is necessary, because otherwise the editor doesn't expose the
     /// CodeMirror library globally for editing the existing instance and this editor can't be filled using regular
     /// Selenium interactions either.
@@ -85,17 +85,17 @@ public static class FormUITestContextExtensions
     public static void SetMarkdownEasyMdeWysiwygEditor(this UITestContext context, string id, string text)
     {
         var script = $@"
-                /* First get rid of the existing editor instance. */
-                document.querySelector('#{id} + .EasyMDEContainer').remove();
-                /* Create a new one using the same call found in OC's MarkdownBodyPart-Wysiwyg.Edit.cshtml */
-                var mde = new EasyMDE({{
-                    element: document.getElementById('{id}'),
-                    forceSync: true,
-                    toolbar: mdeToolbar,
-                    autoDownloadFontAwesome: false,
-                }});
-                /* Finally set the value programmatically. */
-                mde.codemirror.setValue({JsonConvert.SerializeObject(text)});";
+            /* First get rid of the existing editor instance. */
+            document.querySelector('#{id} + .EasyMDEContainer').remove();
+            /* Create a new one using the same call found in OC's MarkdownBodyPart-Wysiwyg.Edit.cshtml */
+            var mde = new EasyMDE({{
+                element: document.getElementById('{id}'),
+                forceSync: true,
+                toolbar: mdeToolbar,
+                autoDownloadFontAwesome: false,
+            }});
+            /* Finally set the value programmatically. */
+            mde.codemirror.setValue({JsonConvert.SerializeObject(text)});";
 
         context.ExecuteScript(script);
     }

--- a/Lombiq.Tests.UI/Extensions/ScriptingUITestContextExtensions.cs
+++ b/Lombiq.Tests.UI/Extensions/ScriptingUITestContextExtensions.cs
@@ -13,7 +13,7 @@ public static class ScriptingUITestContextExtensions
         context.ExecuteLogged(nameof(ExecuteAsyncScript), script, () => context.Driver.ExecuteAsyncScript(script, args));
 
     /// <summary>
-    /// Uses Javascript to set form inputs to values that are hard or impossible by normal means.
+    /// Uses JavaScript to set form inputs to values that are hard or impossible by normal means.
     /// </summary>
     public static void SetValueWithScript(this UITestContext context, string id, object value) =>
         ExecuteScript(

--- a/Lombiq.Tests.UI/Extensions/ScriptingUITestContextExtensions.cs
+++ b/Lombiq.Tests.UI/Extensions/ScriptingUITestContextExtensions.cs
@@ -18,6 +18,13 @@ public static class ScriptingUITestContextExtensions
     public static void SetValueWithScript(this UITestContext context, string id, object value) =>
         ExecuteScript(
             context,
-            $"document.getElementById({JsonConvert.SerializeObject(id)}).value = " +
-            $"{JsonConvert.SerializeObject(value)};");
+            $"document.getElementById({JsonConvert.SerializeObject(id)}).value = {JsonConvert.SerializeObject(value)};");
+
+    /// <summary>
+    /// Uses JavaScript to set textarea values that are hard or impossible by normal means.
+    /// </summary>
+    public static void SetTextContentWithScript(this UITestContext context, string textareaId, object value) =>
+        ExecuteScript(
+            context,
+            $"document.getElementById({JsonConvert.SerializeObject(textareaId)}).textContent = {JsonConvert.SerializeObject(value)};");
 }

--- a/Lombiq.Tests.UI/Services/UITestContext.cs
+++ b/Lombiq.Tests.UI/Services/UITestContext.cs
@@ -214,7 +214,7 @@ public class UITestContext
     /// <summary>
     /// Changes the current tenant context to the Default one. Note that this doesn't navigate the browser.
     /// </summary>
-    public void ChangeCurrentTenantToDefault() => SwitchCurrentTenant("Default", string.Empty);
+    public void SwitchCurrentTenantToDefault() => SwitchCurrentTenant("Default", string.Empty);
 
     /// <summary>
     /// Changes the current tenant context to the provided one. Note that this doesn't navigate the browser.


### PR DESCRIPTION
[OSOE-629](https://lombiq.atlassian.net/browse/OSOE-629)

[OSOE-629]: https://lombiq.atlassian.net/browse/OSOE-629?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ