### PR TITLE
OSOE-657: Set the TypedRoute admin prefix from the UITestContext

### DIFF
--- a/Lombiq.Tests.UI/Extensions/TypedRouteUITestContextExtensions.cs
+++ b/Lombiq.Tests.UI/Extensions/TypedRouteUITestContextExtensions.cs
@@ -1,6 +1,7 @@
 using Lombiq.Tests.UI.Extensions;
 using Lombiq.Tests.UI.Services;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Linq.Expressions;
 using System.Threading.Tasks;
@@ -19,7 +20,7 @@ public static class TypedRouteUITestContextExtensions
         params (string Key, object Value)[] additionalArguments)
         where TController : ControllerBase =>
         context.GoToRelativeUrlAsync(TypedRoute
-            .CreateFromExpression(actionExpression, additionalArguments)
+            .CreateFromExpression(actionExpression, additionalArguments, CreateServiceProvider())
             .ToString());
 
     /// <summary>
@@ -32,6 +33,12 @@ public static class TypedRouteUITestContextExtensions
         params (string Key, object Value)[] additionalArguments)
         where TController : ControllerBase =>
         context.GoToRelativeUrlAsync(TypedRoute
-            .CreateFromExpression(actionExpressionAsync.StripResult(), additionalArguments)
+            .CreateFromExpression(actionExpressionAsync.StripResult(), additionalArguments, CreateServiceProvider())
             .ToString());
+
+    private static IServiceProvider CreateServiceProvider()
+    {
+        var services = new ServiceCollection();
+        return services.BuildServiceProvider();
+    }
 }

--- a/Lombiq.Tests.UI/Extensions/TypedRouteUITestContextExtensions.cs
+++ b/Lombiq.Tests.UI/Extensions/TypedRouteUITestContextExtensions.cs
@@ -2,6 +2,7 @@ using Lombiq.Tests.UI.Extensions;
 using Lombiq.Tests.UI.Services;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
+using OrchardCore.Admin;
 using System;
 using System.Linq.Expressions;
 using System.Threading.Tasks;
@@ -20,7 +21,7 @@ public static class TypedRouteUITestContextExtensions
         params (string Key, object Value)[] additionalArguments)
         where TController : ControllerBase =>
         context.GoToRelativeUrlAsync(TypedRoute
-            .CreateFromExpression(actionExpression, additionalArguments, CreateServiceProvider())
+            .CreateFromExpression(actionExpression, additionalArguments, CreateServiceProvider(context))
             .ToString());
 
     /// <summary>
@@ -33,12 +34,17 @@ public static class TypedRouteUITestContextExtensions
         params (string Key, object Value)[] additionalArguments)
         where TController : ControllerBase =>
         context.GoToRelativeUrlAsync(TypedRoute
-            .CreateFromExpression(actionExpressionAsync.StripResult(), additionalArguments, CreateServiceProvider())
+            .CreateFromExpression(actionExpressionAsync.StripResult(), additionalArguments, CreateServiceProvider(context))
             .ToString());
 
-    private static IServiceProvider CreateServiceProvider()
+    private static IServiceProvider CreateServiceProvider(UITestContext context)
     {
         var services = new ServiceCollection();
+
+        // The AdminOptions.AdminUrlPrefix setter automatically trims out leading or trailing slashes so the format
+        // difference between the two properties doesn't matter.
+        services.Configure<AdminOptions>(options => options.AdminUrlPrefix = context.AdminUrlPrefix);
+
         return services.BuildServiceProvider();
     }
 }


### PR DESCRIPTION
[OSOE-657](https://lombiq.atlassian.net/browse/OSOE-657)

[OSOE-657]: https://lombiq.atlassian.net/browse/OSOE-657?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ