### PR TITLE
OSOE-807: Removing unneeded MultipleActiveResultSets=True config from the default SQL Server connection string

### DIFF
--- a/Lombiq.Tests.UI/Docs/Configuration.md
+++ b/Lombiq.Tests.UI/Docs/Configuration.md
@@ -154,7 +154,7 @@ SQL Server on Linux only has SQL Authentication and you still have to tell the t
 ```json
 {
   "SqlServerDatabaseConfiguration": {
-    "ConnectionStringTemplate": "Server=.;Database=LombiqUITestingToolbox_{{id}};User Id=sa;Password=Password1!;MultipleActiveResultSets=True;Connection Timeout=60;ConnectRetryCount=15;ConnectRetryInterval=5;TrustServerCertificate=true;Encrypt=false"
+    "ConnectionStringTemplate": "Server=.;Database=LombiqUITestingToolbox_{{id}};User Id=sa;Password=Password1!;Connection Timeout=60;ConnectRetryCount=15;ConnectRetryInterval=5;TrustServerCertificate=true;Encrypt=false"
   },
   "DockerConfiguration": {
     "ContainerSnapshotPath": "/data/Snapshots",

--- a/Lombiq.Tests.UI/Docs/Configuration.md
+++ b/Lombiq.Tests.UI/Docs/Configuration.md
@@ -154,7 +154,7 @@ SQL Server on Linux only has SQL Authentication and you still have to tell the t
 ```json
 {
   "SqlServerDatabaseConfiguration": {
-    "ConnectionStringTemplate": "Server=.;Database=LombiqUITestingToolbox_{{id}};User Id=sa;Password=Password1!;Connection Timeout=60;ConnectRetryCount=15;ConnectRetryInterval=5;TrustServerCertificate=true;Encrypt=false"
+    "ConnectionStringTemplate": "Server=.;Database=LombiqUITestingToolbox_{{id}};User Id=sa;Password=Password1!;Connection Timeout=60;ConnectRetryCount=15;ConnectRetryInterval=5;TrustServerCertificate=True;Encrypt=false"
   },
   "DockerConfiguration": {
     "ContainerSnapshotPath": "/data/Snapshots",

--- a/Lombiq.Tests.UI/Docs/Configuration.md
+++ b/Lombiq.Tests.UI/Docs/Configuration.md
@@ -154,7 +154,7 @@ SQL Server on Linux only has SQL Authentication and you still have to tell the t
 ```json
 {
   "SqlServerDatabaseConfiguration": {
-    "ConnectionStringTemplate": "Server=.;Database=LombiqUITestingToolbox_{{id}};User Id=sa;Password=Password1!;Connection Timeout=60;ConnectRetryCount=15;ConnectRetryInterval=5;TrustServerCertificate=True;Encrypt=false"
+    "ConnectionStringTemplate": "Server=.;Database=LombiqUITestingToolbox_{{id}};User Id=sa;Password=Password1!;Connection Timeout=60;ConnectRetryCount=15;ConnectRetryInterval=5;TrustServerCertificate=True;Encrypt=False"
   },
   "DockerConfiguration": {
     "ContainerSnapshotPath": "/data/Snapshots",

--- a/Lombiq.Tests.UI/Services/SqlServerManager.cs
+++ b/Lombiq.Tests.UI/Services/SqlServerManager.cs
@@ -28,7 +28,7 @@ public class SqlServerConfiguration
     public string ConnectionStringTemplate { get; set; } = TestConfigurationManager.GetConfiguration(
         "SqlServerDatabaseConfiguration:ConnectionStringTemplate",
         $"Server=.;Database=LombiqUITestingToolbox_{DatabaseIdPlaceholder};Integrated Security=True;" +
-            "Connection Timeout=60;ConnectRetryCount=15;ConnectRetryInterval=5;TrustServerCertificate=true;Encrypt=false");
+            "Connection Timeout=60;ConnectRetryCount=15;ConnectRetryInterval=5;TrustServerCertificate=True;Encrypt=false");
 }
 
 public class SqlServerRunningContext

--- a/Lombiq.Tests.UI/Services/SqlServerManager.cs
+++ b/Lombiq.Tests.UI/Services/SqlServerManager.cs
@@ -28,7 +28,7 @@ public class SqlServerConfiguration
     public string ConnectionStringTemplate { get; set; } = TestConfigurationManager.GetConfiguration(
         "SqlServerDatabaseConfiguration:ConnectionStringTemplate",
         $"Server=.;Database=LombiqUITestingToolbox_{DatabaseIdPlaceholder};Integrated Security=True;" +
-            "Connection Timeout=60;ConnectRetryCount=15;ConnectRetryInterval=5;TrustServerCertificate=True;Encrypt=false");
+            "Connection Timeout=60;ConnectRetryCount=15;ConnectRetryInterval=5;TrustServerCertificate=True;Encrypt=False");
 }
 
 public class SqlServerRunningContext

--- a/Lombiq.Tests.UI/Services/SqlServerManager.cs
+++ b/Lombiq.Tests.UI/Services/SqlServerManager.cs
@@ -28,8 +28,7 @@ public class SqlServerConfiguration
     public string ConnectionStringTemplate { get; set; } = TestConfigurationManager.GetConfiguration(
         "SqlServerDatabaseConfiguration:ConnectionStringTemplate",
         $"Server=.;Database=LombiqUITestingToolbox_{DatabaseIdPlaceholder};Integrated Security=True;" +
-            "MultipleActiveResultSets=True;Connection Timeout=60;ConnectRetryCount=15;ConnectRetryInterval=5;" +
-            "TrustServerCertificate=true;Encrypt=false");
+            "Connection Timeout=60;ConnectRetryCount=15;ConnectRetryInterval=5;TrustServerCertificate=true;Encrypt=false");
 }
 
 public class SqlServerRunningContext


### PR DESCRIPTION
[OSOE-807](https://lombiq.atlassian.net/browse/OSOE-807)
Fixes #343

[OSOE-807]: https://lombiq.atlassian.net/browse/OSOE-807?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ