### PR TITLE
OCC-218: Exclude \"The filename, directory name, or volume label syntax is incorrect\" error during security testing.

### DIFF
--- a/Lombiq.Tests.UI/Services/OrchardCoreUITestExecutorConfiguration.cs
+++ b/Lombiq.Tests.UI/Services/OrchardCoreUITestExecutorConfiguration.cs
@@ -238,6 +238,7 @@ public class OrchardCoreUITestExecutorConfiguration
             // a directory. Presumably this is an attempt to access protected files using source path manipulation.
             // This is handled by ASP.NET Core and there is nothing for us to worry about.
             "System.IO.IOException: Not a directory",
+            "The filename, directory name, or volume label syntax is incorrect",
             // This happens when a request's model contains a dictionary and a key is missing. While this can be a
             // legitimate application error, during a security scan it's more likely the result of an incomplete
             // artificially constructed request. So the means the ASP.NET Core model binding is working as intended.

--- a/Lombiq.Tests.UI/Services/OrchardCoreUITestExecutorConfiguration.cs
+++ b/Lombiq.Tests.UI/Services/OrchardCoreUITestExecutorConfiguration.cs
@@ -238,7 +238,8 @@ public class OrchardCoreUITestExecutorConfiguration
             // a directory. Presumably this is an attempt to access protected files using source path manipulation.
             // This is handled by ASP.NET Core and there is nothing for us to worry about.
             "System.IO.IOException: Not a directory",
-            "The filename, directory name, or volume label syntax is incorrect",
+            "System.IO.IOException: The filename, directory name, or volume label syntax is incorrect",
+            "System.IO.DirectoryNotFoundException: Could not find a part of the path",
             // This happens when a request's model contains a dictionary and a key is missing. While this can be a
             // legitimate application error, during a security scan it's more likely the result of an incomplete
             // artificially constructed request. So the means the ASP.NET Core model binding is working as intended.


### PR DESCRIPTION
[OCC-218](https://lombiq.atlassian.net/browse/OCC-218)

[OCC-218]: https://lombiq.atlassian.net/browse/OCC-218?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ