### PR TITLE
OSOE-770: Add support for structured html-validate output

### DIFF
--- a/Lombiq.Tests.UI/Docs/Configuration.md
+++ b/Lombiq.Tests.UI/Docs/Configuration.md
@@ -59,51 +59,22 @@ Recommendations and notes for such configuration:
 
 ### HTML validation configuration
 
-If you want to change some HTML validation rules from only a few specific tests, you can create a custom _.htmlvalidate.json_ file (e.g. _TestName.htmlvalidate.json_). For example:
+If you want to change some HTML validation rules for only a few specific tests you can exclude them from the results.
+For example if you want to exclude the `prefer-native-element` rule from the results you can do it by doing the following:
 
-```json
-{
-  "extends": [
-    "html-validate:recommended"
-  ],
-
-  "rules": {
-    "attribute-boolean-style": "off",
-    "element-required-attributes": "off",
-    "no-trailing-whitespace": "off",
-    "no-inline-style": "off",
-    "no-implicit-button-type": "off",
-    "wcag/h30": "off",
-    "wcag/h32": "off",
-    "wcag/h36": "off",
-    "wcag/h37": "off",
-    "wcag/h67": "off",
-    "wcag/h71": "off"
-  },
-
-  "root":  true
-}
+```c#
+configuration => configuration.HtmlValidationConfiguration.AssertHtmlValidationResultAsync =
+    validationResult =>
+    {
+        var errors = validationResult.GetParsedErrors()
+            .Where(error => error.RuleId is not "prefer-native-element");
+        errors.ShouldBeEmpty(string.Join('\n', errors.Select(error => error.Message)));
+        return Task.CompletedTask;
+    });
 ```
 
-Then you can change the configuration to use that:
-
-```cs
- changeConfiguration: configuration => configuration.HtmlValidationConfiguration.HtmlValidationOptions =
-                configuration.HtmlValidationConfiguration.HtmlValidationOptions
-                    .CloneWith(validationOptions => validationOptions.ConfigPath =
-                        Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "TestName.htmlvalidate.json")));
-```
-
-Make sure to also include the `root` attribute and set it to `true` inside the custom _.htmlvalidate.json_ file and include it in the test project like this:
-
-```xml
-  <ItemGroup>
-    <Content Include="TestName.htmlvalidate.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <PackageCopyToOutput>true</PackageCopyToOutput>
-    </Content>
-  </ItemGroup>
- ```
+Note that the `RuleId` is the identifier of the rule that you want to exclude from the results.
+The custom string formatter in the call to `errors.ShouldBeEmpty` is used to display the errors in a more readable way and is not strictly necessary.
 
 ## Multi-process test execution
 

--- a/Lombiq.Tests.UI/Extensions/HtmlValidationResultExtensions.cs
+++ b/Lombiq.Tests.UI/Extensions/HtmlValidationResultExtensions.cs
@@ -29,17 +29,9 @@ public static class HtmlValidationResultExtensions
     /// Gets the parsed errors from the HTML validation result.
     /// Can only be used if the output formatter is set to JSON.
     /// </summary>
-    public static async Task<IEnumerable<HtmlValidationError>> GetParsedErrorsAsync(this HtmlValidationResult result)
-    {
-        if (string.IsNullOrEmpty(result.ResultFilePath) || !File.Exists(result.ResultFilePath))
-        {
-            return Enumerable.Empty<HtmlValidationError>();
-        }
+    public static IEnumerable<JsonHtmlValidationError> GetParsedErrors(this HtmlValidationResult result) => ParseOutput(result.Output);
 
-        return ParseOutput(await File.ReadAllTextAsync(result.ResultFilePath));
-    }
-
-    private static IEnumerable<HtmlValidationError> ParseOutput(string output)
+    private static IEnumerable<JsonHtmlValidationError> ParseOutput(string output)
     {
         output = output.Trim();
         if ((!output.StartsWith('{') || !output.EndsWith('}')) &&
@@ -56,7 +48,7 @@ public static class HtmlValidationResultExtensions
                 .Select(message =>
                 {
                     var rawMessageText = message.GetRawText();
-                    return JsonSerializer.Deserialize<HtmlValidationError>(rawMessageText);
+                    return JsonSerializer.Deserialize<JsonHtmlValidationError>(rawMessageText);
                 });
         }
         catch (JsonException)

--- a/Lombiq.Tests.UI/Extensions/HtmlValidationResultExtensions.cs
+++ b/Lombiq.Tests.UI/Extensions/HtmlValidationResultExtensions.cs
@@ -37,7 +37,7 @@ public static class HtmlValidationResultExtensions
         if ((!output.StartsWith('{') || !output.EndsWith('}')) &&
             (!output.StartsWith('[') || !output.EndsWith(']')))
         {
-            throw new JsonException("Invalid JSON, make sure to set the OutputFormatter to JSON.");
+            throw new JsonException($"Invalid JSON, make sure to set the OutputFormatter to JSON. Output: {output}");
         }
 
         try

--- a/Lombiq.Tests.UI/Extensions/HtmlValidationResultExtensions.cs
+++ b/Lombiq.Tests.UI/Extensions/HtmlValidationResultExtensions.cs
@@ -1,8 +1,11 @@
 using Atata.HtmlValidation;
+using Lombiq.Tests.UI.Models;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 
 namespace Lombiq.Tests.UI.Extensions;
@@ -21,5 +24,45 @@ public static class HtmlValidationResultExtensions
             .Split(Environment.NewLine + Environment.NewLine + "error:", StringSplitOptions.RemoveEmptyEntries)
             .Select(error =>
                 (error.StartsWith("error:", StringComparison.OrdinalIgnoreCase) ? string.Empty : "error:") + error);
+    }
+
+    /// <summary>
+    /// Gets the parsed errors from the HTML validation result.
+    /// Can only be used if the output formatter is set to JSON.
+    /// </summary>
+    public static async Task<IEnumerable<HtmlValidationError>> GetParsedErrorsAsync(this HtmlValidationResult result)
+    {
+        if (string.IsNullOrEmpty(result.ResultFilePath) || !File.Exists(result.ResultFilePath))
+        {
+            return Enumerable.Empty<HtmlValidationError>();
+        }
+
+        return ParseOutput(await File.ReadAllTextAsync(result.ResultFilePath));
+    }
+
+    private static IEnumerable<HtmlValidationError> ParseOutput(string output)
+    {
+        output = output.Trim();
+        if ((!output.StartsWith('{') || !output.EndsWith('}')) &&
+            (!output.StartsWith('[') || !output.EndsWith(']')))
+        {
+            throw new JsonException("Invalid JSON, make sure to set the OutputFormatter to JSON.");
+        }
+
+        try
+        {
+            var document = JsonDocument.Parse(output);
+            return document.RootElement.EnumerateArray()
+                .SelectMany(element => element.GetProperty("messages").EnumerateArray())
+                .Select(message =>
+                {
+                    var rawMessageText = message.GetRawText();
+                    return JsonSerializer.Deserialize<HtmlValidationError>(rawMessageText);
+                });
+        }
+        catch (JsonException)
+        {
+            throw new JsonException("Unable to parse output, did you set the OutputFormatter to JSON?");
+        }
     }
 }

--- a/Lombiq.Tests.UI/Extensions/HtmlValidationResultExtensions.cs
+++ b/Lombiq.Tests.UI/Extensions/HtmlValidationResultExtensions.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text.Json;
-using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 
 namespace Lombiq.Tests.UI.Extensions;

--- a/Lombiq.Tests.UI/Extensions/HtmlValidationUITestContextExtensions.cs
+++ b/Lombiq.Tests.UI/Extensions/HtmlValidationUITestContextExtensions.cs
@@ -1,4 +1,5 @@
 using Atata.Cli;
+using Atata.Cli.HtmlValidate;
 using Atata.HtmlValidation;
 using Lombiq.Tests.UI.Exceptions;
 using Lombiq.Tests.UI.Services;
@@ -53,6 +54,12 @@ public static class HtmlValidationUITestContextExtensions
     {
         var options = context.Configuration.HtmlValidationConfiguration.HtmlValidationOptions.Clone();
         htmlValidationOptionsAdjuster?.Invoke(options);
+
+        // Because of the default settings of Atata.HtmlValidation.HtmlValidationOptions overriding the formatter
+        // we need to set this back to JSON
+        if (options.OutputFormatter == HtmlValidateFormatter.Names.Stylish)
+            options.ResultFileFormatter = HtmlValidateFormatter.Names.Json;
+
         try
         {
             return new HtmlValidator(options).Validate(context.Driver.PageSource);

--- a/Lombiq.Tests.UI/Models/HtmlValidationError.cs
+++ b/Lombiq.Tests.UI/Models/HtmlValidationError.cs
@@ -1,5 +1,4 @@
-﻿using Azure.Core.Serialization;
-using System.Text.Json;
+﻿using System.Text.Json;
 using System.Text.Json.Serialization;
 
 namespace Lombiq.Tests.UI.Models;

--- a/Lombiq.Tests.UI/Models/HtmlValidationError.cs
+++ b/Lombiq.Tests.UI/Models/HtmlValidationError.cs
@@ -1,0 +1,29 @@
+﻿using Azure.Core.Serialization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Lombiq.Tests.UI.Models;
+
+public class HtmlValidationError
+{
+    [JsonPropertyName("ruleId")]
+    public string RuleId { get; set; }
+    [JsonPropertyName("severity")]
+    public int Severity { get; set; }
+    [JsonPropertyName("message")]
+    public string Message { get; set; }
+    [JsonPropertyName("offset")]
+    public int Offset { get; set; }
+    [JsonPropertyName("line")]
+    public int Line { get; set; }
+    [JsonPropertyName("column")]
+    public int Column { get; set; }
+    [JsonPropertyName("size")]
+    public int Size { get; set; }
+    [JsonPropertyName("selector")]
+    public string Selector { get; set; }
+    [JsonPropertyName("ruleUrl")]
+    public string RuleUrl { get; set; }
+    [JsonPropertyName("context")]
+    public JsonElement Context { get; set; }
+}

--- a/Lombiq.Tests.UI/Models/JsonHtmlValidationError.cs
+++ b/Lombiq.Tests.UI/Models/JsonHtmlValidationError.cs
@@ -3,7 +3,7 @@ using System.Text.Json.Serialization;
 
 namespace Lombiq.Tests.UI.Models;
 
-public class HtmlValidationError
+public class JsonHtmlValidationError
 {
     [JsonPropertyName("ruleId")]
     public string RuleId { get; set; }

--- a/Lombiq.Tests.UI/Services/HtmlValidationConfiguration.cs
+++ b/Lombiq.Tests.UI/Services/HtmlValidationConfiguration.cs
@@ -4,6 +4,7 @@ using Lombiq.Tests.UI.Extensions;
 using Lombiq.Tests.UI.Helpers;
 using Shouldly;
 using System;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace Lombiq.Tests.UI.Services;
@@ -66,18 +67,21 @@ public class HtmlValidationConfiguration
         EnableOnValidatablePagesHtmlValidationAndAssertionOnPageChangeRule;
 
     public static readonly Func<HtmlValidationResult, Task> AssertHtmlValidationOutputIsEmptyAsync =
-        async validationResult =>
+        validationResult =>
         {
             // Keep supporting cases where output format is not set to JSON.
             if (validationResult.Output.Trim().StartsWith('[') ||
                 validationResult.Output.Trim().StartsWith('{'))
             {
-                validationResult.GetParsedErrors().ShouldBeEmpty();
+                var errors = validationResult.GetParsedErrors();
+                errors.ShouldBeEmpty(string.Join('\n', errors.Select(error => error.Message)));
             }
             else
             {
                 validationResult.Output.ShouldBeEmpty();
             }
+
+            return Task.CompletedTask;
         };
 
     public static readonly Predicate<UITestContext> EnableOnValidatablePagesHtmlValidationAndAssertionOnPageChangeRule =

--- a/Lombiq.Tests.UI/Services/HtmlValidationConfiguration.cs
+++ b/Lombiq.Tests.UI/Services/HtmlValidationConfiguration.cs
@@ -30,7 +30,7 @@ public class HtmlValidationConfiguration
     /// </summary>
     public HtmlValidationOptions HtmlValidationOptions { get; set; } = new()
     {
-        ResultFileFormatter = HtmlValidateFormatter.Names.Json,
+        ResultFileFormatter = HtmlValidateFormatter.Names.Text,
         OutputFormatter = HtmlValidateFormatter.Names.Json,
         SaveHtmlToFile = HtmlSaveCondition.Never,
         SaveResultToFile = true,
@@ -72,7 +72,7 @@ public class HtmlValidationConfiguration
             if (validationResult.Output.Trim().StartsWith('[') ||
                 validationResult.Output.Trim().StartsWith('{'))
             {
-                (await validationResult.GetParsedErrorsAsync()).ShouldBeEmpty();
+                validationResult.GetParsedErrors().ShouldBeEmpty();
             }
             else
             {

--- a/Lombiq.Tests.UI/Services/HtmlValidationConfiguration.cs
+++ b/Lombiq.Tests.UI/Services/HtmlValidationConfiguration.cs
@@ -1,3 +1,4 @@
+using Atata.Cli.HtmlValidate;
 using Atata.HtmlValidation;
 using Lombiq.Tests.UI.Helpers;
 using Shouldly;
@@ -28,6 +29,8 @@ public class HtmlValidationConfiguration
     /// </summary>
     public HtmlValidationOptions HtmlValidationOptions { get; set; } = new()
     {
+        ResultFileFormatter = HtmlValidateFormatter.Names.Json,
+        OutputFormatter = HtmlValidateFormatter.Names.Json,
         SaveHtmlToFile = HtmlSaveCondition.Never,
         SaveResultToFile = true,
         // This is necessary so no long folder names will be generated, see:

--- a/Lombiq.Tests.UI/Services/HtmlValidationConfiguration.cs
+++ b/Lombiq.Tests.UI/Services/HtmlValidationConfiguration.cs
@@ -66,7 +66,19 @@ public class HtmlValidationConfiguration
         EnableOnValidatablePagesHtmlValidationAndAssertionOnPageChangeRule;
 
     public static readonly Func<HtmlValidationResult, Task> AssertHtmlValidationOutputIsEmptyAsync =
-        async validationResult => (await validationResult.GetParsedErrorsAsync()).ShouldBeEmpty();
+        async validationResult =>
+        {
+            // Keep supporting cases where output format is not set to JSON.
+            if (validationResult.Output.Trim().StartsWith('[') ||
+                validationResult.Output.Trim().StartsWith('{'))
+            {
+                (await validationResult.GetParsedErrorsAsync()).ShouldBeEmpty();
+            }
+            else
+            {
+                validationResult.Output.ShouldBeEmpty();
+            }
+        };
 
     public static readonly Predicate<UITestContext> EnableOnValidatablePagesHtmlValidationAndAssertionOnPageChangeRule =
         UrlCheckHelper.IsValidatablePage;

--- a/Lombiq.Tests.UI/Services/HtmlValidationConfiguration.cs
+++ b/Lombiq.Tests.UI/Services/HtmlValidationConfiguration.cs
@@ -65,12 +65,9 @@ public class HtmlValidationConfiguration
     public Predicate<UITestContext> HtmlValidationAndAssertionOnPageChangeRule { get; set; } =
         EnableOnValidatablePagesHtmlValidationAndAssertionOnPageChangeRule;
 
-    private static readonly Func<HtmlValidationResult, Task<Task>> AssertHtmlValidationOutputIsEmptyAsync = async validationResult =>
-        {
-            (await validationResult.GetParsedErrorsAsync()).ShouldBeEmpty();
-            return Task.CompletedTask;
-        };
+    public static readonly Func<HtmlValidationResult, Task> AssertHtmlValidationOutputIsEmptyAsync =
+        async validationResult => (await validationResult.GetParsedErrorsAsync()).ShouldBeEmpty();
 
-    private static readonly Predicate<UITestContext> EnableOnValidatablePagesHtmlValidationAndAssertionOnPageChangeRule =
+    public static readonly Predicate<UITestContext> EnableOnValidatablePagesHtmlValidationAndAssertionOnPageChangeRule =
         UrlCheckHelper.IsValidatablePage;
 }

--- a/Lombiq.Tests.UI/Services/HtmlValidationConfiguration.cs
+++ b/Lombiq.Tests.UI/Services/HtmlValidationConfiguration.cs
@@ -1,5 +1,6 @@
 using Atata.Cli.HtmlValidate;
 using Atata.HtmlValidation;
+using Lombiq.Tests.UI.Extensions;
 using Lombiq.Tests.UI.Helpers;
 using Shouldly;
 using System;
@@ -64,13 +65,12 @@ public class HtmlValidationConfiguration
     public Predicate<UITestContext> HtmlValidationAndAssertionOnPageChangeRule { get; set; } =
         EnableOnValidatablePagesHtmlValidationAndAssertionOnPageChangeRule;
 
-    public static readonly Func<HtmlValidationResult, Task> AssertHtmlValidationOutputIsEmptyAsync =
-        validationResult =>
+    private static readonly Func<HtmlValidationResult, Task<Task>> AssertHtmlValidationOutputIsEmptyAsync = async validationResult =>
         {
-            validationResult.Output.ShouldBeEmpty();
+            (await validationResult.GetParsedErrorsAsync()).ShouldBeEmpty();
             return Task.CompletedTask;
         };
 
-    public static readonly Predicate<UITestContext> EnableOnValidatablePagesHtmlValidationAndAssertionOnPageChangeRule =
+    private static readonly Predicate<UITestContext> EnableOnValidatablePagesHtmlValidationAndAssertionOnPageChangeRule =
         UrlCheckHelper.IsValidatablePage;
 }


### PR DESCRIPTION
[OSOE-770](https://lombiq.atlassian.net/browse/OSOE-770)
Added ability to get parsed html-validate output
Fixes #337

[OSOE-770]: https://lombiq.atlassian.net/browse/OSOE-770?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ