### PR TITLE
OSOE-537: Migrate from `Selenium.Axe` to `TWP.Selenium.Axe.Html` in Lombiq.UITestingToolbox

### DIFF
--- a/Lombiq.Tests.UI/Exceptions/AccessibilityAssertionException.cs
+++ b/Lombiq.Tests.UI/Exceptions/AccessibilityAssertionException.cs
@@ -1,4 +1,4 @@
-using Selenium.Axe;
+using Deque.AxeCore.Commons;
 using System;
 
 namespace Lombiq.Tests.UI.Exceptions;

--- a/Lombiq.Tests.UI/Extensions/AccessibilityCheckingOrchardCoreUITestExecutorConfigurationExtensions.cs
+++ b/Lombiq.Tests.UI/Extensions/AccessibilityCheckingOrchardCoreUITestExecutorConfigurationExtensions.cs
@@ -1,5 +1,6 @@
+using Deque.AxeCore.Commons;
+using Deque.AxeCore.Selenium;
 using Lombiq.Tests.UI.Services;
-using Selenium.Axe;
 using System;
 using System.Threading.Tasks;
 

--- a/Lombiq.Tests.UI/Extensions/AccessibilityCheckingUITestContextExtensions.cs
+++ b/Lombiq.Tests.UI/Extensions/AccessibilityCheckingUITestContextExtensions.cs
@@ -1,8 +1,10 @@
+using Deque.AxeCore.Commons;
+using Deque.AxeCore.Selenium;
 using Lombiq.Tests.UI.Exceptions;
 using Lombiq.Tests.UI.Services;
-using Selenium.Axe;
 using System;
 using System.IO;
+using TWP.Selenium.Axe.Html;
 
 namespace Lombiq.Tests.UI.Extensions;
 

--- a/Lombiq.Tests.UI/Extensions/AxeResultItemExtensions.cs
+++ b/Lombiq.Tests.UI/Extensions/AxeResultItemExtensions.cs
@@ -1,5 +1,5 @@
+using Deque.AxeCore.Commons;
 using Lombiq.Tests.UI.Services;
-using Selenium.Axe;
 using Shouldly;
 using System.Collections.Generic;
 

--- a/Lombiq.Tests.UI/Lombiq.Tests.UI.csproj
+++ b/Lombiq.Tests.UI/Lombiq.Tests.UI.csproj
@@ -66,6 +66,8 @@
     <PackageReference Include="Azure.Storage.Blobs" Version="12.19.1" />
     <PackageReference Include="Ben.Demystifier" Version="0.4.1" />
     <PackageReference Include="Codeuctivity.ImageSharpCompare" Version="4.0.258" />
+    <PackageReference Include="Deque.AxeCore.Commons" Version="4.9.1" />
+    <PackageReference Include="Deque.AxeCore.Selenium" Version="4.9.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
     <PackageReference Include="Microsoft.SqlServer.DACFx" Version="162.2.111" />
@@ -77,9 +79,9 @@
     <PackageReference Include="OrchardCore.Recipes.Core" Version="1.8.0" />
     <PackageReference Include="Refit.HttpClientFactory" Version="7.0.0" />
     <PackageReference Include="Sarif.Sdk" Version="4.5.4" />
-    <PackageReference Include="Selenium.Axe" Version="4.0.17" />
     <PackageReference Include="Shouldly" Version="4.2.1" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
+    <PackageReference Include="TWP.Selenium.Axe.Html" Version="1.0.0" />
     <PackageReference Include="xunit" Version="2.8.0" />
     <PackageReference Include="YamlDotNet" Version="15.1.4" />
   </ItemGroup>

--- a/Lombiq.Tests.UI/Services/AccessibilityCheckingConfiguration.cs
+++ b/Lombiq.Tests.UI/Services/AccessibilityCheckingConfiguration.cs
@@ -1,6 +1,7 @@
+using Deque.AxeCore.Commons;
+using Deque.AxeCore.Selenium;
 using Lombiq.Tests.UI.Extensions;
 using Lombiq.Tests.UI.Helpers;
-using Selenium.Axe;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/Lombiq.Tests.UI/Services/UITestExecutionSession.cs
+++ b/Lombiq.Tests.UI/Services/UITestExecutionSession.cs
@@ -11,13 +11,13 @@ using Lombiq.Tests.UI.Services.GitHub;
 using Microsoft.VisualBasic.FileIO;
 using Mono.Unix;
 using Newtonsoft.Json.Linq;
-using Selenium.Axe;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using TWP.Selenium.Axe.Html;
 using Xunit.Abstractions;
 using Xunit.Sdk;
 


### PR DESCRIPTION
[OSOE-537](https://lombiq.atlassian.net/browse/OSOE-537)
Fixes #256

[OSOE-537]: https://lombiq.atlassian.net/browse/OSOE-537?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ