### PR TITLE
OSOE-873: Disable "allow pasting" warning in Chrome's dev tools

### DIFF
--- a/Lombiq.Tests.UI/Services/WebDriverFactory.cs
+++ b/Lombiq.Tests.UI/Services/WebDriverFactory.cs
@@ -33,6 +33,10 @@ public static class WebDriverFactory
             // https://developers.google.com/web/tools/puppeteer/troubleshooting#tips for more information.
             chromeConfig.Options.AddArgument("disable-dev-shm-usage"); // #spell-check-ignore-line
 
+            // Disables the "self-XSS" warning in dev tools (when you have to type "allow pasting"), see
+            // https://developer.chrome.com/blog/self-xss and https://issues.chromium.org/issues/41491762 for details.
+            chromeConfig.Options.AddArgument("unsafely-disable-devtools-self-xss-warnings"); // #spell-check-ignore-line
+
             chromeConfig.Options.SetCommonChromiumOptions(configuration);
 
             configuration.BrowserOptionsConfigurator?.Invoke(chromeConfig.Options);


### PR DESCRIPTION
[OSOE-873](https://lombiq.atlassian.net/browse/OSOE-873)
Fixes #382

[OSOE-873]: https://lombiq.atlassian.net/browse/OSOE-873?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ