### PR TITLE
LMBQ-401: Adapting security scanning URL excludes to OC 2.0 upgrade

### DIFF
--- a/Lombiq.Tests.UI/Helpers/UrlCheckHelper.cs
+++ b/Lombiq.Tests.UI/Helpers/UrlCheckHelper.cs
@@ -32,6 +32,8 @@ public static class UrlCheckHelper
                path.StartsWithOrdinalIgnoreCase("/Login") ||
                path.StartsWithOrdinalIgnoreCase("/ChangePassword") ||
                path.StartsWithOrdinalIgnoreCase("/ExternalAuthentications") ||
+               path.StartsWithOrdinalIgnoreCase("/ExternalLogins") ||
+               path.StartsWithOrdinalIgnoreCase("/ExternalLogin") ||
                context.IsSetupPage();
     }
 

--- a/Lombiq.Tests.UI/Helpers/UrlCheckHelper.cs
+++ b/Lombiq.Tests.UI/Helpers/UrlCheckHelper.cs
@@ -31,7 +31,7 @@ public static class UrlCheckHelper
                path.StartsWithOrdinalIgnoreCase("/Register") ||
                path.StartsWithOrdinalIgnoreCase("/Login") ||
                path.StartsWithOrdinalIgnoreCase("/ChangePassword") ||
-               path.StartsWithOrdinalIgnoreCase("/ExternalLogins") ||
+               path.StartsWithOrdinalIgnoreCase("/ExternalAuthentications") ||
                context.IsSetupPage();
     }
 

--- a/Lombiq.Tests.UI/Helpers/UrlCheckHelper.cs
+++ b/Lombiq.Tests.UI/Helpers/UrlCheckHelper.cs
@@ -31,8 +31,6 @@ public static class UrlCheckHelper
                path.StartsWithOrdinalIgnoreCase("/Register") ||
                path.StartsWithOrdinalIgnoreCase("/Login") ||
                path.StartsWithOrdinalIgnoreCase("/ChangePassword") ||
-               path.StartsWithOrdinalIgnoreCase("/ExternalAuthentications") ||
-               path.StartsWithOrdinalIgnoreCase("/ExternalLogins") ||
                path.StartsWithOrdinalIgnoreCase("/ExternalLogin") ||
                context.IsSetupPage();
     }

--- a/Lombiq.Tests.UI/SecurityScanning/AutomationFrameworkPlans/FullScan.yml
+++ b/Lombiq.Tests.UI/SecurityScanning/AutomationFrameworkPlans/FullScan.yml
@@ -105,7 +105,7 @@ jobs:
         newRisk: False Positive
         parameter: ''
         parameterRegex: false
-        url: .*/(ChangePassword|ExternalAuthentication/LinkExternalLogin|ExternalAuthentication/ExternalLogin|Users/LogOff|api/content).*
+        url: .*/(ChangePassword|ExternalAuthentications/LinkExternalLogin|ExternalAuthentications/ExternalLogin|Users/LogOff|api/content).*
         urlRegex: true
         attack: ''
         attackRegex: false

--- a/Lombiq.Tests.UI/SecurityScanning/AutomationFrameworkPlans/FullScan.yml
+++ b/Lombiq.Tests.UI/SecurityScanning/AutomationFrameworkPlans/FullScan.yml
@@ -105,7 +105,7 @@ jobs:
         newRisk: False Positive
         parameter: ''
         parameterRegex: false
-        url: .*/(ChangePassword|Account/LinkLogin|Account/ExternalLogin|Users/LogOff|api/content).*
+        url: .*/(ChangePassword|ExternalAuthentication/LinkExternalLogin|ExternalAuthentication/ExternalLogin|Users/LogOff|api/content).*
         urlRegex: true
         attack: ''
         attackRegex: false


### PR DESCRIPTION
[LMBQ-401](https://lombiq.atlassian.net/browse/LMBQ-401)

[LMBQ-401]: https://lombiq.atlassian.net/browse/LMBQ-401?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ