### PR TITLE
OSOE-402: Custom logging instead of NLog-based one

### DIFF
--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -9,6 +9,6 @@ jobs:
   publish-nuget:
     name: Publish to NuGet
     if: ${{ !contains(github.ref_name, '-preview.') }}
-    uses: Lombiq/GitHub-Actions/.github/workflows/publish-nuget.yml@dev
+    uses: Lombiq/GitHub-Actions/.github/workflows/publish-nuget.yml@issue/OSOE-402
     secrets:
       API_KEY: ${{ secrets.DEFAULT_NUGET_PUBLISH_API_KEY }}

--- a/.github/workflows/validate-nuget-publish.yml
+++ b/.github/workflows/validate-nuget-publish.yml
@@ -9,4 +9,4 @@ on:
 jobs:
   validate-nuget-publish:
     name: Validate NuGet Publish
-    uses: Lombiq/GitHub-Actions/.github/workflows/validate-nuget-publish.yml@dev
+    uses: Lombiq/GitHub-Actions/.github/workflows/validate-nuget-publish.yml@issue/OSOE-402

--- a/Lombiq.Tests.UI.Samples/Tests/DatabaseSnapshotTests.cs
+++ b/Lombiq.Tests.UI.Samples/Tests/DatabaseSnapshotTests.cs
@@ -23,19 +23,19 @@ public class DatabaseSnapshotTests : UITestBase
     // "ExecuteTestFromExistingDBAsync()" to run the test on that. Finally, we test the basic Orchard features to check
     // that the application was set up correctly.
     [Fact]
-    public Task BasicOrchardFeaturesShouldWorkWithExistingDatabase() =>
-         ExecuteTestAsync(
-                async context =>
-                {
-                    var appForDatabaseTestFolder = Path.Combine("Temp", "AppForDatabaseTest");
+    public async Task BasicOrchardFeaturesShouldWorkWithExistingDatabase()
+    {
+        var appForDatabaseTestFolder = Path.Combine("Temp", "AppForDatabaseTest");
 
-                    await context.GoToSetupPageAndSetupOrchardCoreAsync(RecipeIds.BasicOrchardFeaturesTests);
-                    await context.Application.TakeSnapshotAsync(appForDatabaseTestFolder);
+        await ExecuteTestAsync(
+            async context =>
+            {
+                await context.GoToSetupPageAndSetupOrchardCoreAsync(RecipeIds.BasicOrchardFeaturesTests);
+                await context.Application.TakeSnapshotAsync(appForDatabaseTestFolder);
+            });
 
-                    await ExecuteTestFromExistingDBAsync(
-                         async context => await context.TestBasicOrchardFeaturesExceptSetupAsync(),
-                         appForDatabaseTestFolder);
-                });
+        await ExecuteTestFromExistingDBAsync(context => context.TestBasicOrchardFeaturesExceptSetupAsync(), appForDatabaseTestFolder);
+    }
 }
 
 // END OF TRAINING SECTION: Database snapshot tests.

--- a/Lombiq.Tests.UI.Samples/Tests/ErrorHandlingTests.cs
+++ b/Lombiq.Tests.UI.Samples/Tests/ErrorHandlingTests.cs
@@ -38,7 +38,7 @@ public class ErrorHandlingTests : UITestBase
                 catch (PageChangeAssertionException)
                 {
                     // Remove all logs to have a clean slate.
-                    context.ClearLogs();
+                    await context.ClearLogsAsync();
                 }
             });
 

--- a/Lombiq.Tests.UI.Samples/Tests/ShiftTimeTests.cs
+++ b/Lombiq.Tests.UI.Samples/Tests/ShiftTimeTests.cs
@@ -10,11 +10,11 @@ using Xunit.Abstractions;
 
 namespace Lombiq.Tests.UI.Samples.Tests;
 
-// When you enable the "Shift Time - Shortcuts - Lombiq UI Testing Toolbox" feature, it replaces OC's stock ICLock
-// implementation with the custom ShiftTimeClock class. You can use the ~/Lombiq.Tests.UI.Samples/ShiftTime/Set?days=...
-// action to update the ShiftTimeClock.Shift property for the current tenant, which will trick any service that uses
-// IClock into thinking you are in the future. This can be used to test features that can expire, such as a limited-time
-// product discount in a web store.
+// When you enable the "Shift Time - Shortcuts - Lombiq UI Testing Toolbox" feature, it replaces Orchard Core's stock
+// ICLock implementation with the custom ShiftTimeClock class. You can use the
+// ~/Lombiq.Tests.UI.Samples/ShiftTime/Set?days=... action to update the ShiftTimeClock.Shift property for the current
+// tenant, which will trick any service that uses IClock into thinking you are in the future. This can be used to test
+// features that can expire, such as a limited-time product discount in a web store, without having to wait.
 public class ShiftTimeTests : UITestBase
 {
     public ShiftTimeTests(ITestOutputHelper testOutputHelper)

--- a/Lombiq.Tests.UI.Samples/UITestBase.cs
+++ b/Lombiq.Tests.UI.Samples/UITestBase.cs
@@ -2,6 +2,7 @@ using Lombiq.Tests.UI.Constants;
 using Lombiq.Tests.UI.Extensions;
 using Lombiq.Tests.UI.Samples.Helpers;
 using Lombiq.Tests.UI.Services;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Threading.Tasks;
 using Xunit.Abstractions;
@@ -64,7 +65,8 @@ public abstract class UITestBase : OrchardCoreUITestBase<Program>
                 // https://docs.orchardcore.net/en/latest/docs/reference/core/Configuration/. We can set e.g. Orchard's
                 // AdminUrlPrefix like below, but this is just setting the default, so it's only an example. A more
                 // useful example is enabling offline operation of the Lombiq Hosting - Azure Application Insights for
-                // Orchard Core module (see https://github.com/Lombiq/Orchard-Azure-Application-Insights).
+                // Orchard Core module (see the UI test project in
+                // https://github.com/Lombiq/Orchard-Azure-Application-Insights).
                 configuration.OrchardCoreConfiguration.BeforeAppStart +=
                     (_, argumentsBuilder) =>
                     {
@@ -82,14 +84,41 @@ public abstract class UITestBase : OrchardCoreUITestBase<Program>
                 // Action) to further configure it.
                 ////configuration.HtmlValidationConfiguration.RunHtmlValidationAssertionOnAllPageChanges = false;
 
-                // The UI Testing Toolbox can run several checks for the app even if you don't add explicit
-                // assertions: By default, the Orchard logs and the browser logs (where e.g. JavaScript errors show
-                // up) are checked and if there are any errors, the test will fail. You can also enable the checking of
-                // accessibility rules as we'll see later. Maybe not all of the default checks are suitable for you.
-                // Then it's simple to override them; here we change which log entries cause the tests to fail, and
-                // allow certain log entries.
+                // For locally running apps, the UI Testing Toolbox configures Fake Logging (see
+                // https://learn.microsoft.com/en-us/dotnet/api/microsoft.extensions.logging.testing). This provides an
+                // in-memory log for assertions, regardless of the logging framework your app uses otherwise. By
+                // default, it'll only collect log entries with the Error level and up. However, you can change this,
+                // and the usual Logging app settings still work.
+                configuration.OrchardCoreConfiguration.BeforeAppStart +=
+                    (_, argumentsBuilder) =>
+                    {
+                        // This is how you can configure logging to be on the >=Error level in general, while still
+                        // allowing info-level entries for ShellHost.
+                        argumentsBuilder
+                            .AddWithValue("Logging:LogLevel:Default", "Error")
+                            .AddWithValue("Logging:LogLevel:System", "Error")
+                            .AddWithValue("Logging:LogLevel:Microsoft", "Error")
+                            .AddWithValue("Logging:LogLevel:OrchardCore.Environment.Shell.ShellHost", "Information");
+
+                        return Task.CompletedTask;
+                    };
+
+                // Enabling FakeLogger to collect the info-level ShellHost log entries configured above. These will show
+                // up in the test's output like "[Information] OrchardCore.Environment.Shell.ShellHost: Start creation
+                // of shells".
+                configuration.OrchardCoreConfiguration.AfterFakeLoggingConfiguration =
+                    (_, fakeLogCollectorOptions) => fakeLogCollectorOptions.FilteredLevels.Add(LogLevel.Information);
+
+                // Logging is important because the UI Testing Toolbox can run several checks for the app even if you
+                // don't add explicit assertions: By default, the Orchard logs and the browser logs (where e.g.
+                // JavaScript errors show up) are checked and if there are any errors, the test will fail. You can also
+                // enable the checking of accessibility rules as we'll see later. Maybe not all of the default checks
+                // are suitable for you. Then it's simple to override them; here we change which log entries cause the
+                // tests to fail, and allow certain log entries.
                 configuration.AssertAppLogsAsync = webApplicationInstance =>
-                    webApplicationInstance.LogsShouldNotContainAsync(logEntry => logEntry.Message != "My permitted message.");
+                    webApplicationInstance.LogsShouldNotContainAsync(logEntry =>
+                    // Allowing info-level log entries for ShellHost, see above.
+                    logEntry.Message != "My permitted message." && logEntry.Level != LogLevel.Information);
 
                 // Strictly speaking this is not necessary here, because we always use the same static method for setup.
                 // However, if you used a dynamic setup operation (e.g. `context => SetupHelpers.RunSetupAsync(context,

--- a/Lombiq.Tests.UI.Samples/UITestBase.cs
+++ b/Lombiq.Tests.UI.Samples/UITestBase.cs
@@ -87,17 +87,9 @@ public abstract class UITestBase : OrchardCoreUITestBase<Program>
                 // up) are checked and if there are any errors, the test will fail. You can also enable the checking of
                 // accessibility rules as we'll see later. Maybe not all of the default checks are suitable for you.
                 // Then it's simple to override them; here we change which log entries cause the tests to fail, and
-                // allow warnings and certain errors.
-                // Note that this is just for demonstration; you could use
-                // OrchardCoreUITestExecutorConfiguration.AssertAppLogsCanContainWarningsAndCacheFolderErrorsAsync which
-                // provides this configuration built-in.
+                // allow certain log entries.
                 configuration.AssertAppLogsAsync = webApplicationInstance =>
-                    webApplicationInstance.LogsShouldBeEmptyAsync(
-                        canContainWarnings: true,
-                        permittedErrorLinePatterns:
-                        [
-                            "OrchardCore.Media.Core.DefaultMediaFileStoreCacheFileProvider|ERROR|Error deleting cache folder",
-                        ]);
+                    webApplicationInstance.LogsShouldNotContainAsync(logEntry => logEntry.Message != "My permitted message.");
 
                 // Strictly speaking this is not necessary here, because we always use the same static method for setup.
                 // However, if you used a dynamic setup operation (e.g. `context => SetupHelpers.RunSetupAsync(context,

--- a/Lombiq.Tests.UI.Shortcuts/Controllers/ShiftTimeController.cs
+++ b/Lombiq.Tests.UI.Shortcuts/Controllers/ShiftTimeController.cs
@@ -1,3 +1,4 @@
+using Lombiq.HelpfulLibraries.AspNetCore.Mvc;
 using Lombiq.Tests.UI.Shortcuts.Services;
 using Microsoft.AspNetCore.Mvc;
 using OrchardCore.Modules;
@@ -10,6 +11,7 @@ namespace Lombiq.Tests.UI.Shortcuts.Controllers;
     "Major Code Smell",
     "S6967:ModelState.IsValid should be called in controller actions",
     Justification = "Not relevant in a test-only controller.")]
+[DevelopmentAndLocalhostOnly]
 public class ShiftTimeController : Controller
 {
     private readonly IClock _clock;

--- a/Lombiq.Tests.UI.Shortcuts/Controllers/ShiftTimeController.cs
+++ b/Lombiq.Tests.UI.Shortcuts/Controllers/ShiftTimeController.cs
@@ -3,14 +3,9 @@ using Lombiq.Tests.UI.Shortcuts.Services;
 using Microsoft.AspNetCore.Mvc;
 using OrchardCore.Modules;
 using System;
-using System.Diagnostics.CodeAnalysis;
 
 namespace Lombiq.Tests.UI.Shortcuts.Controllers;
 
-[SuppressMessage(
-    "Major Code Smell",
-    "S6967:ModelState.IsValid should be called in controller actions",
-    Justification = "Not relevant in a test-only controller.")]
 [DevelopmentAndLocalhostOnly]
 public class ShiftTimeController : Controller
 {

--- a/Lombiq.Tests.UI.Tests.UI/TestCases/SecurityShortcutsTestCases.cs
+++ b/Lombiq.Tests.UI.Tests.UI/TestCases/SecurityShortcutsTestCases.cs
@@ -48,7 +48,7 @@ public static class SecurityShortcutsTestCases
                 await context.CreateUserAsync(UserUserName, DefaultUser.Password, UserEmail);
                 await context.AddUserToRoleAsync(UserUserName, FakeRole).ShouldThrowAsync<RoleNotFoundException>();
 
-                context.ClearLogs();
+                await context.ClearLogsAsync();
             },
             browser,
             ConfigurationHelper.DisableHtmlValidation);
@@ -61,7 +61,7 @@ public static class SecurityShortcutsTestCases
                 await context.AddPermissionToRoleAsync(FakePermission, AuthorRole)
                     .ShouldThrowAsync<PermissionNotFoundException>();
 
-                context.ClearLogs();
+                await context.ClearLogsAsync();
             },
             browser,
             ConfigurationHelper.DisableHtmlValidation);

--- a/Lombiq.Tests.UI/CompatibilitySuppressions.xml
+++ b/Lombiq.Tests.UI/CompatibilitySuppressions.xml
@@ -1,0 +1,39 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- https://learn.microsoft.com/en-us/dotnet/fundamentals/package-validation/diagnostic-ids -->
+<Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Lombiq.Tests.UI.Services.IApplicationLog.GetContentAsync</Target>
+    <Left>lib/net8.0/Lombiq.Tests.UI.dll</Left>
+    <Right>lib/net8.0/Lombiq.Tests.UI.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Lombiq.Tests.UI.Services.IWebApplicationInstance.GetRequiredService``1</Target>
+    <Left>lib/net8.0/Lombiq.Tests.UI.dll</Left>
+    <Right>lib/net8.0/Lombiq.Tests.UI.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Lombiq.Tests.UI.Services.OrchardCoreInstance`1.GetRequiredService``1</Target>
+    <Left>lib/net8.0/Lombiq.Tests.UI.dll</Left>
+    <Right>lib/net8.0/Lombiq.Tests.UI.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0006</DiagnosticId>
+    <Target>M:Lombiq.Tests.UI.Services.IApplicationLog.GetContentAsync</Target>
+    <Left>lib/net8.0/Lombiq.Tests.UI.dll</Left>
+    <Right>lib/net8.0/Lombiq.Tests.UI.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0006</DiagnosticId>
+    <Target>P:Lombiq.Tests.UI.Services.IApplicationLog.MessageCount</Target>
+    <Left>lib/net8.0/Lombiq.Tests.UI.dll</Left>
+    <Right>lib/net8.0/Lombiq.Tests.UI.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+</Suppressions>

--- a/Lombiq.Tests.UI/CompatibilitySuppressions.xml
+++ b/Lombiq.Tests.UI/CompatibilitySuppressions.xml
@@ -3,7 +3,49 @@
 <Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
+    <Target>F:Lombiq.Tests.UI.Services.OrchardCoreUITestExecutorConfiguration.AssertAppLogsCanContainWarningsAndCacheFolderErrorsAsync</Target>
+    <Left>lib/net8.0/Lombiq.Tests.UI.dll</Left>
+    <Right>lib/net8.0/Lombiq.Tests.UI.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>F:Lombiq.Tests.UI.Services.OrchardCoreUITestExecutorConfiguration.AssertAppLogsCanContainWarningsAsync</Target>
+    <Left>lib/net8.0/Lombiq.Tests.UI.dll</Left>
+    <Right>lib/net8.0/Lombiq.Tests.UI.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Lombiq.Tests.UI.Extensions.WebApplicationInstanceExtensions.GetLogOutputAsync(Lombiq.Tests.UI.Services.IWebApplicationInstance,System.Threading.CancellationToken)</Target>
+    <Left>lib/net8.0/Lombiq.Tests.UI.dll</Left>
+    <Right>lib/net8.0/Lombiq.Tests.UI.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Lombiq.Tests.UI.Extensions.WebApplicationInstanceExtensions.LogsShouldBeEmptyAsync(Lombiq.Tests.UI.Services.IWebApplicationInstance,System.Boolean,System.Collections.Generic.ICollection{System.String},System.Threading.CancellationToken)</Target>
+    <Left>lib/net8.0/Lombiq.Tests.UI.dll</Left>
+    <Right>lib/net8.0/Lombiq.Tests.UI.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:Lombiq.Tests.UI.Services.IApplicationLog.GetContentAsync</Target>
+    <Left>lib/net8.0/Lombiq.Tests.UI.dll</Left>
+    <Right>lib/net8.0/Lombiq.Tests.UI.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Lombiq.Tests.UI.Services.IApplicationLog.Remove</Target>
+    <Left>lib/net8.0/Lombiq.Tests.UI.dll</Left>
+    <Right>lib/net8.0/Lombiq.Tests.UI.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Lombiq.Tests.UI.Services.IWebApplicationInstance.GetLogs(System.Threading.CancellationToken)</Target>
     <Left>lib/net8.0/Lombiq.Tests.UI.dll</Left>
     <Right>lib/net8.0/Lombiq.Tests.UI.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
@@ -17,21 +59,84 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Lombiq.Tests.UI.Services.OrchardCoreInstance`1.GetLogs(System.Threading.CancellationToken)</Target>
+    <Left>lib/net8.0/Lombiq.Tests.UI.dll</Left>
+    <Right>lib/net8.0/Lombiq.Tests.UI.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
     <Target>M:Lombiq.Tests.UI.Services.OrchardCoreInstance`1.GetRequiredService``1</Target>
     <Left>lib/net8.0/Lombiq.Tests.UI.dll</Left>
     <Right>lib/net8.0/Lombiq.Tests.UI.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
-    <DiagnosticId>CP0006</DiagnosticId>
-    <Target>M:Lombiq.Tests.UI.Services.IApplicationLog.GetContentAsync</Target>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Lombiq.Tests.UI.Services.OrchardCoreUITestExecutorConfiguration.AssertAppLogsMaybeAsync(Lombiq.Tests.UI.Services.IWebApplicationInstance,System.Action{System.String})</Target>
+    <Left>lib/net8.0/Lombiq.Tests.UI.dll</Left>
+    <Right>lib/net8.0/Lombiq.Tests.UI.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Lombiq.Tests.UI.Services.OrchardCoreUITestExecutorConfiguration.AssertBrowserLogMaybe(System.Collections.Generic.IList{OpenQA.Selenium.LogEntry},System.Action{System.String})</Target>
+    <Left>lib/net8.0/Lombiq.Tests.UI.dll</Left>
+    <Right>lib/net8.0/Lombiq.Tests.UI.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Lombiq.Tests.UI.Services.OrchardCoreUITestExecutorConfiguration.CreateAppLogAssertionForSecurityScan(System.String[])</Target>
+    <Left>lib/net8.0/Lombiq.Tests.UI.dll</Left>
+    <Right>lib/net8.0/Lombiq.Tests.UI.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Lombiq.Tests.UI.Services.OrchardCoreUITestExecutorConfiguration.UseAssertAppLogsForSecurityScan(System.String[])</Target>
+    <Left>lib/net8.0/Lombiq.Tests.UI.dll</Left>
+    <Right>lib/net8.0/Lombiq.Tests.UI.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Lombiq.Tests.UI.Services.RemoteInstance.GetLogs(System.Threading.CancellationToken)</Target>
+    <Left>lib/net8.0/Lombiq.Tests.UI.dll</Left>
+    <Right>lib/net8.0/Lombiq.Tests.UI.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Lombiq.Tests.UI.Services.UITestContext.ClearLogs(System.Threading.CancellationToken)</Target>
     <Left>lib/net8.0/Lombiq.Tests.UI.dll</Left>
     <Right>lib/net8.0/Lombiq.Tests.UI.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0006</DiagnosticId>
-    <Target>P:Lombiq.Tests.UI.Services.IApplicationLog.MessageCount</Target>
+    <Target>M:Lombiq.Tests.UI.Services.IApplicationLog.GetEntriesAsync</Target>
+    <Left>lib/net8.0/Lombiq.Tests.UI.dll</Left>
+    <Right>lib/net8.0/Lombiq.Tests.UI.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0006</DiagnosticId>
+    <Target>M:Lombiq.Tests.UI.Services.IApplicationLog.RemoveAsync</Target>
+    <Left>lib/net8.0/Lombiq.Tests.UI.dll</Left>
+    <Right>lib/net8.0/Lombiq.Tests.UI.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0006</DiagnosticId>
+    <Target>M:Lombiq.Tests.UI.Services.IWebApplicationInstance.GetLogsAsync(System.Threading.CancellationToken)</Target>
+    <Left>lib/net8.0/Lombiq.Tests.UI.dll</Left>
+    <Right>lib/net8.0/Lombiq.Tests.UI.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0006</DiagnosticId>
+    <Target>P:Lombiq.Tests.UI.Services.IApplicationLog.EntryCount</Target>
     <Left>lib/net8.0/Lombiq.Tests.UI.dll</Left>
     <Right>lib/net8.0/Lombiq.Tests.UI.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>

--- a/Lombiq.Tests.UI/Docs/Troubleshooting.md
+++ b/Lombiq.Tests.UI/Docs/Troubleshooting.md
@@ -7,7 +7,7 @@
   - Browser logs, i.e. the developer console output.
   - Screenshots of each page in order the test visited them, as well as when the test failed (Windows Photo Viewer won't be able to open it though, use something else like the Windows 10 Photos app).
   - The HTML output on the page the test failed.
-  - Any direct output of the test (like the exception thrown) as well as a log of the operations it completed.
+  - Any direct output of the test (like the exception thrown) as well as a log of the operations it completed (including browser interactions and corresponding Orchard Core log entries).
   - If accessibility was checked and asserting it failed then an accessibility report will be included too.
   - If HTML validation was done and asserting it failed then an HTML validation report will be included too.
 - Run tests with the debugger attached to stop where the test fails. This way you can take a good look at what's in the driven browser window so you can examine the web page and you can debug the web app under test at the same time.

--- a/Lombiq.Tests.UI/Extensions/ApplicationLogEnumerableExtensions.cs
+++ b/Lombiq.Tests.UI/Extensions/ApplicationLogEnumerableExtensions.cs
@@ -17,14 +17,12 @@ public static class ApplicationLogEnumerableExtensions
             return Environment.NewLine + await LogLinesToFormattedStringAsync(logsArray[0]);
         }
 
-        return string.Join(
-            Environment.NewLine + Environment.NewLine,
-            await Task.WhenAll(
-                logsArray.Select(async log =>
-                    $"# Log name: {log.Name}" +
-                    Environment.NewLine +
-                    Environment.NewLine +
-                    await LogLinesToFormattedStringAsync(log))));
+        // Parallelization with Task.WhenAll() isn't really necessary for performance here but would potentially change
+        // the order of the logs in the output.
+        var logContents = logsArray.AwaitEachAsync(async log =>
+            $"# Log name: {log.Name}" + Environment.NewLine + Environment.NewLine + await LogLinesToFormattedStringAsync(log));
+
+        return string.Join(Environment.NewLine + Environment.NewLine, logContents);
     }
 
     private static async Task<string> LogLinesToFormattedStringAsync(IApplicationLog log) =>

--- a/Lombiq.Tests.UI/Extensions/ApplicationLogEnumerableExtensions.cs
+++ b/Lombiq.Tests.UI/Extensions/ApplicationLogEnumerableExtensions.cs
@@ -13,8 +13,8 @@ public static class ApplicationLogEnumerableExtensions
             Environment.NewLine + Environment.NewLine,
             await Task.WhenAll(
                 logs.Select(async log =>
-                    log.Name +
+                    $"# Log name: {log.Name}" +
                     Environment.NewLine +
                     Environment.NewLine +
-                    (await log.GetContentAsync()).Select(logMessage => logMessage.ToString()))));
+                    string.Join(Environment.NewLine, (await log.GetEntriesAsync()).Select(logEntry => logEntry.ToString())))));
 }

--- a/Lombiq.Tests.UI/Extensions/ApplicationLogEnumerableExtensions.cs
+++ b/Lombiq.Tests.UI/Extensions/ApplicationLogEnumerableExtensions.cs
@@ -11,5 +11,10 @@ public static class ApplicationLogEnumerableExtensions
     public static async Task<string> ToFormattedStringAsync(this IEnumerable<IApplicationLog> logs) =>
         string.Join(
             Environment.NewLine + Environment.NewLine,
-            await Task.WhenAll(logs.Select(async log => log.Name + Environment.NewLine + Environment.NewLine + await log.GetContentAsync())));
+            await Task.WhenAll(
+                logs.Select(async log =>
+                    log.Name +
+                    Environment.NewLine +
+                    Environment.NewLine +
+                    (await log.GetContentAsync()).Select(logMessage => logMessage.ToString()))));
 }

--- a/Lombiq.Tests.UI/Extensions/ApplicationLogEnumerableExtensions.cs
+++ b/Lombiq.Tests.UI/Extensions/ApplicationLogEnumerableExtensions.cs
@@ -8,13 +8,25 @@ namespace Lombiq.Tests.UI.Extensions;
 
 public static class ApplicationLogEnumerableExtensions
 {
-    public static async Task<string> ToFormattedStringAsync(this IEnumerable<IApplicationLog> logs) =>
-        string.Join(
+    public static async Task<string> ToFormattedStringAsync(this IEnumerable<IApplicationLog> logs)
+    {
+        var logsArray = logs.ToArray();
+
+        if (logsArray.Length == 1)
+        {
+            return Environment.NewLine + await LogLinesToFormattedStringAsync(logsArray[0]);
+        }
+
+        return string.Join(
             Environment.NewLine + Environment.NewLine,
             await Task.WhenAll(
-                logs.Select(async log =>
+                logsArray.Select(async log =>
                     $"# Log name: {log.Name}" +
                     Environment.NewLine +
                     Environment.NewLine +
-                    string.Join(Environment.NewLine, (await log.GetEntriesAsync()).Select(logEntry => logEntry.ToString())))));
+                    await LogLinesToFormattedStringAsync(log))));
+    }
+
+    private static async Task<string> LogLinesToFormattedStringAsync(IApplicationLog log) =>
+        string.Join(Environment.NewLine, (await log.GetEntriesAsync()).Select(logEntry => logEntry.ToString()));
 }

--- a/Lombiq.Tests.UI/Extensions/BrowserUITestContextExtensions.cs
+++ b/Lombiq.Tests.UI/Extensions/BrowserUITestContextExtensions.cs
@@ -1,4 +1,4 @@
-﻿using Lombiq.Tests.UI.Extensions;
+using Lombiq.Tests.UI.Extensions;
 using Lombiq.Tests.UI.Services;
 using System.Diagnostics.CodeAnalysis;
 using System.Net.Http;
@@ -87,7 +87,7 @@ public static class BrowserUITestContextExtensions
         }
         catch
         {
-            context.ClearLogs();
+            await context.ClearLogsAsync();
             return true;
         }
 

--- a/Lombiq.Tests.UI/Extensions/ShortcutsUITestContextExtensions.cs
+++ b/Lombiq.Tests.UI/Extensions/ShortcutsUITestContextExtensions.cs
@@ -733,5 +733,5 @@ public static class ShortcutsUITestContextExtensions
     /// provided, then the <see cref="TimeSpan"/> values for both are added. Negative values are supported as well.
     /// </summary>
     public static Task AddShiftTimeAsync(this UITestContext context, double days = 0, double seconds = 0) =>
-        context.GoToAsync<ShiftTimeController>(controller => controller.Set(days, seconds));
+        context.GoToAsync<ShiftTimeController>(controller => controller.Add(days, seconds));
 }

--- a/Lombiq.Tests.UI/Extensions/VerificationUITestContextExtensions.cs
+++ b/Lombiq.Tests.UI/Extensions/VerificationUITestContextExtensions.cs
@@ -29,7 +29,7 @@ public static class VerificationUITestContextExtensions
         catch (Exception)
         {
             testOutputHelper.WriteLine("Application logs: " + Environment.NewLine);
-            testOutputHelper.WriteLine(await context.Application.GetLogOutputAsync());
+            testOutputHelper.WriteLine(await context.Application.GetLogContentsAsync());
 
             throw;
         }

--- a/Lombiq.Tests.UI/Extensions/WebApplicationInstanceExtensions.cs
+++ b/Lombiq.Tests.UI/Extensions/WebApplicationInstanceExtensions.cs
@@ -103,14 +103,14 @@ public static class WebApplicationInstanceExtensions
     private static async Task AssertLogsAsync(
         IWebApplicationInstance webApplicationInstance,
         Expression<Func<IApplicationLogEntry, bool>> logEntryPredicate,
-        Action<IEnumerable<IApplicationLogEntry>, Expression<Func<IApplicationLogEntry, bool>>, string> shouldlyMethod,
+        Action<IEnumerable<IApplicationLogEntry>, Expression<Func<IApplicationLogEntry, bool>>, string> shouldlyMethod, // #spell-check-ignore-line
         CancellationToken cancellationToken = default)
     {
         var logs = await webApplicationInstance.GetLogsAsync(cancellationToken);
 
         foreach (var log in logs)
         {
-            shouldlyMethod(await log.GetEntriesAsync(), logEntryPredicate, await logs.ToFormattedStringAsync());
+            shouldlyMethod(await log.GetEntriesAsync(), logEntryPredicate, await logs.ToFormattedStringAsync()); // #spell-check-ignore-line
         }
     }
 }

--- a/Lombiq.Tests.UI/Extensions/WebApplicationInstanceExtensions.cs
+++ b/Lombiq.Tests.UI/Extensions/WebApplicationInstanceExtensions.cs
@@ -48,7 +48,7 @@ public static class WebApplicationInstanceExtensions
         this IWebApplicationInstance webApplicationInstance,
         Expression<Func<IApplicationLogEntry, bool>> logEntryPredicate,
         CancellationToken cancellationToken = default) =>
-        AssertLogsAsyn(webApplicationInstance, logEntryPredicate, ShouldBeEnumerableTestExtensions.ShouldContain, cancellationToken);
+        AssertLogsAsync(webApplicationInstance, logEntryPredicate, ShouldBeEnumerableTestExtensions.ShouldContain, cancellationToken);
 
     /// <summary>
     /// Asserts that the logs should NOT contain any entries matching the given predicate. If the assertion fails, the
@@ -68,7 +68,7 @@ public static class WebApplicationInstanceExtensions
         this IWebApplicationInstance webApplicationInstance,
         Expression<Func<IApplicationLogEntry, bool>> logEntryPredicate,
         CancellationToken cancellationToken = default) =>
-        AssertLogsAsyn(webApplicationInstance, logEntryPredicate, ShouldBeEnumerableTestExtensions.ShouldNotContain, cancellationToken);
+        AssertLogsAsync(webApplicationInstance, logEntryPredicate, ShouldBeEnumerableTestExtensions.ShouldNotContain, cancellationToken);
 
     /// <summary>
     /// Retrieves all the logs and concatenates them into a single formatted string.
@@ -100,7 +100,7 @@ public static class WebApplicationInstanceExtensions
     public static TService GetRequiredService<TService>(this IWebApplicationInstance webApplicationInstance) =>
         webApplicationInstance.Services.GetRequiredService<TService>();
 
-    private static async Task AssertLogsAsyn(
+    private static async Task AssertLogsAsync(
         IWebApplicationInstance webApplicationInstance,
         Expression<Func<IApplicationLogEntry, bool>> logEntryPredicate,
         Action<IEnumerable<IApplicationLogEntry>, Expression<Func<IApplicationLogEntry, bool>>, string> shouldlyMethod,

--- a/Lombiq.Tests.UI/Extensions/WebApplicationInstanceExtensions.cs
+++ b/Lombiq.Tests.UI/Extensions/WebApplicationInstanceExtensions.cs
@@ -53,6 +53,12 @@ public static class WebApplicationInstanceExtensions
     /// <summary>
     /// Retrieves all the logs and concatenates them into a single formatted string.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// If you want to inspect the logs in a more structured way, message by message, consider using <see
+    /// cref="IWebApplicationInstance.GetLogs(CancellationToken)"/> directly instead.
+    /// </para>
+    /// </remarks>
     public static async Task<string> GetLogOutputAsync(
         this IWebApplicationInstance webApplicationInstance,
         CancellationToken cancellationToken = default)

--- a/Lombiq.Tests.UI/Extensions/WebApplicationInstanceExtensions.cs
+++ b/Lombiq.Tests.UI/Extensions/WebApplicationInstanceExtensions.cs
@@ -1,8 +1,8 @@
 using Lombiq.Tests.UI.Services;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 using Shouldly;
 using System;
+using System.Linq.Expressions;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -28,26 +28,16 @@ public static class WebApplicationInstanceExtensions
         logs.ShouldNotContain(log => log.MessageCount > 0, await logs.ToFormattedStringAsync());
     }
 
-    /// <summary>
-    /// Asserting that the logs should not contain messages with the <see cref="LogLevel"/> greater than or equal to
-    /// <see cref="LogLevel.Error"/>. When they do, the Shouldly exception will contain the logs' contents.
-    /// </summary>
-    /// <remarks>
-    /// <para>
-    /// If you want to inspect the logs in a more structured way, message by message, consider using <see
-    /// cref="IWebApplicationInstance.GetLogsAsync(CancellationToken)"/> directly instead.
-    /// </para>
-    /// </remarks>
-    public static async Task LogsShouldNotContainErrorsAsync(
+    public static async Task LogsShouldNotContainAsync(
         this IWebApplicationInstance webApplicationInstance,
+        Expression<Func<IApplicationLogEntry, bool>> logEntryPredicate,
         CancellationToken cancellationToken = default)
     {
         var logs = await webApplicationInstance.GetLogsAsync(cancellationToken);
 
         foreach (var log in logs)
         {
-            (await log.GetContentAsync())
-                .ShouldNotContain(logMessage => logMessage.Level > LogLevel.Warning, await logs.ToFormattedStringAsync());
+            (await log.GetEntriesAsync()).ShouldNotContain(logEntryPredicate, await logs.ToFormattedStringAsync());
         }
     }
 

--- a/Lombiq.Tests.UI/Extensions/WebApplicationInstanceExtensions.cs
+++ b/Lombiq.Tests.UI/Extensions/WebApplicationInstanceExtensions.cs
@@ -1,10 +1,8 @@
 using Lombiq.Tests.UI.Services;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Shouldly;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -16,37 +14,40 @@ public static class WebApplicationInstanceExtensions
     /// Asserting that the logs should be empty. When they aren't the Shouldly exception will contain the logs'
     /// contents.
     /// </summary>
-    /// <param name="permittedErrorLinePatterns">
-    /// If not <see langword="null"/> or empty, each line is split and any lines containing <c>|ERROR|</c> will be
-    /// ignored if they regex match any string from this collection (case-insensitive).
-    /// </param>
+    /// <remarks>
+    /// <para>
+    /// If you want to inspect the logs in a more structured way, message by message, consider using <see
+    /// cref="IWebApplicationInstance.GetLogsAsync(CancellationToken)"/> directly instead.
+    /// </para>
+    /// </remarks>
     public static async Task LogsShouldBeEmptyAsync(
         this IWebApplicationInstance webApplicationInstance,
-        bool canContainWarnings = false,
-        ICollection<string> permittedErrorLinePatterns = null,
         CancellationToken cancellationToken = default)
     {
-        permittedErrorLinePatterns ??= [];
+        var logs = await webApplicationInstance.GetLogsAsync(cancellationToken);
+        logs.ShouldNotContain(log => log.MessageCount > 0, await logs.ToFormattedStringAsync());
+    }
 
-        var logOutput = await webApplicationInstance.GetLogOutputAsync(cancellationToken);
+    /// <summary>
+    /// Asserting that the logs should not contain messages with the <see cref="LogLevel"/> greater than or equal to
+    /// <see cref="LogLevel.Error"/>. When they do, the Shouldly exception will contain the logs' contents.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// If you want to inspect the logs in a more structured way, message by message, consider using <see
+    /// cref="IWebApplicationInstance.GetLogsAsync(CancellationToken)"/> directly instead.
+    /// </para>
+    /// </remarks>
+    public static async Task LogsShouldNotContainErrorsAsync(
+        this IWebApplicationInstance webApplicationInstance,
+        CancellationToken cancellationToken = default)
+    {
+        var logs = await webApplicationInstance.GetLogsAsync(cancellationToken);
 
-        logOutput.ShouldNotContain("|FATAL|");
-
-        var lines = logOutput.SplitByNewLines();
-
-        var errorLines = lines.Where(line => line.Contains("|ERROR|"));
-
-        if (permittedErrorLinePatterns.Count != 0)
+        foreach (var log in logs)
         {
-            errorLines = errorLines.Where(line =>
-                !permittedErrorLinePatterns.Any(pattern => Regex.IsMatch(line, pattern, RegexOptions.IgnoreCase | RegexOptions.Compiled)));
-        }
-
-        errorLines.ShouldBeEmpty();
-
-        if (!canContainWarnings)
-        {
-            lines.Where(line => line.Contains("|WARNING|")).ShouldBeEmpty();
+            (await log.GetContentAsync())
+                .ShouldNotContain(logMessage => logMessage.Level > LogLevel.Warning, await logs.ToFormattedStringAsync());
         }
     }
 
@@ -56,7 +57,7 @@ public static class WebApplicationInstanceExtensions
     /// <remarks>
     /// <para>
     /// If you want to inspect the logs in a more structured way, message by message, consider using <see
-    /// cref="IWebApplicationInstance.GetLogs(CancellationToken)"/> directly instead.
+    /// cref="IWebApplicationInstance.GetLogsAsync(CancellationToken)"/> directly instead.
     /// </para>
     /// </remarks>
     public static async Task<string> GetLogOutputAsync(
@@ -65,9 +66,7 @@ public static class WebApplicationInstanceExtensions
     {
         if (cancellationToken == default) cancellationToken = CancellationToken.None;
 
-        return string.Join(
-            Environment.NewLine + Environment.NewLine,
-            await webApplicationInstance.GetLogs(cancellationToken).ToFormattedStringAsync());
+        return await (await webApplicationInstance.GetLogsAsync(cancellationToken)).ToFormattedStringAsync();
     }
 
     /// <summary>

--- a/Lombiq.Tests.UI/Extensions/WebApplicationInstanceExtensions.cs
+++ b/Lombiq.Tests.UI/Extensions/WebApplicationInstanceExtensions.cs
@@ -18,7 +18,9 @@ public static class WebApplicationInstanceExtensions
     /// <remarks>
     /// <para>
     /// If you want to inspect the logs in a more structured way, message by message, consider using <see
-    /// cref="IWebApplicationInstance.GetLogsAsync(CancellationToken)"/> directly instead.
+    /// cref="IWebApplicationInstance.GetLogsAsync(CancellationToken)"/> directly instead. Alternatively, set log
+    /// filtering options to not log unwanted messages in first place with the standard Logging:LogLevel app
+    /// configuration (see the samples).
     /// </para>
     /// </remarks>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/> that can cancel the log retrieval.</param>
@@ -37,7 +39,9 @@ public static class WebApplicationInstanceExtensions
     /// <remarks>
     /// <para>
     /// If you want to inspect the logs in a more structured way, message by message, consider using <see
-    /// cref="IWebApplicationInstance.GetLogsAsync(CancellationToken)"/> directly instead.
+    /// cref="IWebApplicationInstance.GetLogsAsync(CancellationToken)"/> directly instead. Alternatively, set log
+    /// filtering options to not log unwanted messages in first place with the standard Logging:LogLevel app
+    /// configuration (see the samples).
     /// </para>
     /// </remarks>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/> that can cancel the log retrieval.</param>
@@ -57,7 +61,9 @@ public static class WebApplicationInstanceExtensions
     /// <remarks>
     /// <para>
     /// If you want to inspect the logs in a more structured way, message by message, consider using <see
-    /// cref="IWebApplicationInstance.GetLogsAsync(CancellationToken)"/> directly instead.
+    /// cref="IWebApplicationInstance.GetLogsAsync(CancellationToken)"/> directly instead. Alternatively, set log
+    /// filtering options to not log unwanted messages in first place with the standard Logging:LogLevel app
+    /// configuration (see the samples).
     /// </para>
     /// </remarks>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/> that can cancel the log retrieval.</param>
@@ -76,7 +82,9 @@ public static class WebApplicationInstanceExtensions
     /// <remarks>
     /// <para>
     /// If you want to inspect the logs in a more structured way, message by message, consider using <see
-    /// cref="IWebApplicationInstance.GetLogsAsync(CancellationToken)"/> directly instead.
+    /// cref="IWebApplicationInstance.GetLogsAsync(CancellationToken)"/> directly instead. Alternatively, set log
+    /// filtering options to not log unwanted messages in first place with the standard Logging:LogLevel app
+    /// configuration (see the samples).
     /// </para>
     /// </remarks>
     /// <param name="cancellationToken">A <see cref="CancellationToken"/> that can cancel the log retrieval.</param>

--- a/Lombiq.Tests.UI/Extensions/WebApplicationInstanceExtensions.cs
+++ b/Lombiq.Tests.UI/Extensions/WebApplicationInstanceExtensions.cs
@@ -2,6 +2,7 @@ using Lombiq.Tests.UI.Services;
 using Microsoft.Extensions.DependencyInjection;
 using Shouldly;
 using System;
+using System.Collections.Generic;
 using System.Linq.Expressions;
 using System.Threading;
 using System.Threading.Tasks;
@@ -11,8 +12,8 @@ namespace Lombiq.Tests.UI.Extensions;
 public static class WebApplicationInstanceExtensions
 {
     /// <summary>
-    /// Asserting that the logs should be empty. When they aren't the Shouldly exception will contain the logs'
-    /// contents.
+    /// Asserts that the logs should be empty, i.e. contain no entries. If the assertion fails, the Shouldly exception
+    /// will contain all log entries.
     /// </summary>
     /// <remarks>
     /// <para>
@@ -20,26 +21,54 @@ public static class WebApplicationInstanceExtensions
     /// cref="IWebApplicationInstance.GetLogsAsync(CancellationToken)"/> directly instead.
     /// </para>
     /// </remarks>
+    /// <param name="cancellationToken">A <see cref="CancellationToken"/> that can cancel the log retrieval.</param>
     public static async Task LogsShouldBeEmptyAsync(
         this IWebApplicationInstance webApplicationInstance,
         CancellationToken cancellationToken = default)
     {
         var logs = await webApplicationInstance.GetLogsAsync(cancellationToken);
-        logs.ShouldNotContain(log => log.MessageCount > 0, await logs.ToFormattedStringAsync());
+        logs.ShouldNotContain(log => log.EntryCount > 0, await logs.ToFormattedStringAsync());
     }
 
-    public static async Task LogsShouldNotContainAsync(
+    /// <summary>
+    /// Asserts that the logs should contain any entry matching the given predicate. If the assertion fails, the
+    /// Shouldly exception will contain all log entries.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// If you want to inspect the logs in a more structured way, message by message, consider using <see
+    /// cref="IWebApplicationInstance.GetLogsAsync(CancellationToken)"/> directly instead.
+    /// </para>
+    /// </remarks>
+    /// <param name="cancellationToken">A <see cref="CancellationToken"/> that can cancel the log retrieval.</param>
+    /// <param name="logEntryPredicate">
+    /// A predicate that when returns <see langword="true"/>, the assertion will fail.
+    /// </param>
+    public static Task LogsShouldContainAsync(
         this IWebApplicationInstance webApplicationInstance,
         Expression<Func<IApplicationLogEntry, bool>> logEntryPredicate,
-        CancellationToken cancellationToken = default)
-    {
-        var logs = await webApplicationInstance.GetLogsAsync(cancellationToken);
+        CancellationToken cancellationToken = default) =>
+        AssertLogsAsyn(webApplicationInstance, logEntryPredicate, ShouldBeEnumerableTestExtensions.ShouldContain, cancellationToken);
 
-        foreach (var log in logs)
-        {
-            (await log.GetEntriesAsync()).ShouldNotContain(logEntryPredicate, await logs.ToFormattedStringAsync());
-        }
-    }
+    /// <summary>
+    /// Asserts that the logs should NOT contain any entries matching the given predicate. If the assertion fails, the
+    /// Shouldly exception will contain all log entries.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// If you want to inspect the logs in a more structured way, message by message, consider using <see
+    /// cref="IWebApplicationInstance.GetLogsAsync(CancellationToken)"/> directly instead.
+    /// </para>
+    /// </remarks>
+    /// <param name="cancellationToken">A <see cref="CancellationToken"/> that can cancel the log retrieval.</param>
+    /// <param name="logEntryPredicate">
+    /// A predicate that when returns <see langword="true"/>, the assertion will fail.
+    /// </param>
+    public static Task LogsShouldNotContainAsync(
+        this IWebApplicationInstance webApplicationInstance,
+        Expression<Func<IApplicationLogEntry, bool>> logEntryPredicate,
+        CancellationToken cancellationToken = default) =>
+        AssertLogsAsyn(webApplicationInstance, logEntryPredicate, ShouldBeEnumerableTestExtensions.ShouldNotContain, cancellationToken);
 
     /// <summary>
     /// Retrieves all the logs and concatenates them into a single formatted string.
@@ -50,7 +79,8 @@ public static class WebApplicationInstanceExtensions
     /// cref="IWebApplicationInstance.GetLogsAsync(CancellationToken)"/> directly instead.
     /// </para>
     /// </remarks>
-    public static async Task<string> GetLogOutputAsync(
+    /// <param name="cancellationToken">A <see cref="CancellationToken"/> that can cancel the log retrieval.</param>
+    public static async Task<string> GetLogContentsAsync(
         this IWebApplicationInstance webApplicationInstance,
         CancellationToken cancellationToken = default)
     {
@@ -62,11 +92,25 @@ public static class WebApplicationInstanceExtensions
     /// <summary>
     /// Get service of type <typeparamref name="TService"/>.
     /// </summary>
-    /// <typeparam name="TService">The type of service object to get.</typeparam>
-    /// <returns>A service object of type <typeparamref name="TService"/>.</returns>
+    /// <typeparam name="TService">The type of service service to get.</typeparam>
+    /// <returns>An instance of the service of type <typeparamref name="TService"/>.</returns>
     /// <exception cref="InvalidOperationException">
     /// There is no service of type <typeparamref name="TService"/>.
     /// </exception>
     public static TService GetRequiredService<TService>(this IWebApplicationInstance webApplicationInstance) =>
         webApplicationInstance.Services.GetRequiredService<TService>();
+
+    private static async Task AssertLogsAsyn(
+        IWebApplicationInstance webApplicationInstance,
+        Expression<Func<IApplicationLogEntry, bool>> logEntryPredicate,
+        Action<IEnumerable<IApplicationLogEntry>, Expression<Func<IApplicationLogEntry, bool>>, string> shouldlyMethod,
+        CancellationToken cancellationToken = default)
+    {
+        var logs = await webApplicationInstance.GetLogsAsync(cancellationToken);
+
+        foreach (var log in logs)
+        {
+            shouldlyMethod(await log.GetEntriesAsync(), logEntryPredicate, await logs.ToFormattedStringAsync());
+        }
+    }
 }

--- a/Lombiq.Tests.UI/Extensions/WebApplicationInstanceExtensions.cs
+++ b/Lombiq.Tests.UI/Extensions/WebApplicationInstanceExtensions.cs
@@ -1,5 +1,6 @@
 using Lombiq.Tests.UI.Services;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Shouldly;
 using System;
 using System.Collections.Generic;
@@ -53,6 +54,28 @@ public static class WebApplicationInstanceExtensions
         Expression<Func<IApplicationLogEntry, bool>> logEntryPredicate,
         CancellationToken cancellationToken = default) =>
         AssertLogsAsync(webApplicationInstance, logEntryPredicate, ShouldBeEnumerableTestExtensions.ShouldContain, cancellationToken);
+
+    /// <summary>
+    /// Asserts that the logs should NOT contain any entries with <see cref="LogLevel.Error"/> and above. If the
+    /// assertion fails, the Shouldly exception will contain all log entries.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// If you want to inspect the logs in a more structured way, message by message, consider using <see
+    /// cref="IWebApplicationInstance.GetLogsAsync(CancellationToken)"/> directly instead. Alternatively, set log
+    /// filtering options to not log unwanted messages in first place with the standard Logging:LogLevel app
+    /// configuration (see the samples).
+    /// </para>
+    /// </remarks>
+    /// <param name="cancellationToken">A <see cref="CancellationToken"/> that can cancel the log retrieval.</param>
+    public static Task LogsShouldNotContainErrorsAsync(
+        this IWebApplicationInstance webApplicationInstance,
+        CancellationToken cancellationToken = default) =>
+        AssertLogsAsync(
+            webApplicationInstance,
+            logEntry => logEntry.Level > LogLevel.Error,
+            ShouldBeEnumerableTestExtensions.ShouldNotContain,
+            cancellationToken);
 
     /// <summary>
     /// Asserts that the logs should NOT contain any entries matching the given predicate. If the assertion fails, the

--- a/Lombiq.Tests.UI/Extensions/WebApplicationInstanceExtensions.cs
+++ b/Lombiq.Tests.UI/Extensions/WebApplicationInstanceExtensions.cs
@@ -1,4 +1,5 @@
 using Lombiq.Tests.UI.Services;
+using Microsoft.Extensions.DependencyInjection;
 using Shouldly;
 using System;
 using System.Collections.Generic;
@@ -62,4 +63,15 @@ public static class WebApplicationInstanceExtensions
             Environment.NewLine + Environment.NewLine,
             await webApplicationInstance.GetLogs(cancellationToken).ToFormattedStringAsync());
     }
+
+    /// <summary>
+    /// Get service of type <typeparamref name="TService"/>.
+    /// </summary>
+    /// <typeparam name="TService">The type of service object to get.</typeparam>
+    /// <returns>A service object of type <typeparamref name="TService"/>.</returns>
+    /// <exception cref="InvalidOperationException">
+    /// There is no service of type <typeparamref name="TService"/>.
+    /// </exception>
+    public static TService GetRequiredService<TService>(this IWebApplicationInstance webApplicationInstance) =>
+        webApplicationInstance.Services.GetRequiredService<TService>();
 }

--- a/Lombiq.Tests.UI/Helpers/AppLogAssertionHelper.cs
+++ b/Lombiq.Tests.UI/Helpers/AppLogAssertionHelper.cs
@@ -1,0 +1,23 @@
+using Lombiq.Tests.UI.Services;
+using System;
+using System.Linq.Expressions;
+
+namespace Lombiq.Tests.UI.Helpers;
+
+public static class AppLogAssertionHelper
+{
+    /// <summary>
+    /// An <see cref="Expression"/> wrapping <see cref="NotMediaCacheEntries(IApplicationLogEntry)"/>.
+    /// </summary>
+    public static readonly Expression<Func<IApplicationLogEntry, bool>> NotMediaCacheEntriesPredicate =
+        logEntry => NotMediaCacheEntries(logEntry);
+
+    /// <summary>
+    /// Creates a predicate that can be used to filter out "Error deleting cache folder" log entries coming from
+    /// <c>DefaultMediaFileStoreCacheFileProvider</c>. These errors frequently happen during UI testing when using Azure
+    /// Blob Storage for media storage. They're harmless, though.
+    /// </summary>
+    public static bool NotMediaCacheEntries(IApplicationLogEntry logEntry) =>
+        logEntry.Category != "OrchardCore.Media.Core.DefaultMediaFileStoreCacheFileProvider" ||
+        !logEntry.Message.StartsWithOrdinalIgnoreCase("Error deleting cache folder");
+}

--- a/Lombiq.Tests.UI/Lombiq.Tests.UI.csproj
+++ b/Lombiq.Tests.UI/Lombiq.Tests.UI.csproj
@@ -74,6 +74,7 @@
     <PackageReference Include="Deque.AxeCore.Selenium" Version="4.9.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.Testing" Version="8.10.0" />
     <PackageReference Include="Microsoft.SqlServer.DACFx" Version="162.2.111" />
     <PackageReference Include="Microsoft.SqlServer.SqlManagementObjects" Version="171.30.0" />
     <PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0" />

--- a/Lombiq.Tests.UI/Models/FakeLoggerLogApplicationLog.cs
+++ b/Lombiq.Tests.UI/Models/FakeLoggerLogApplicationLog.cs
@@ -12,7 +12,7 @@ public sealed class FakeLoggerLogApplicationLog : IApplicationLog
 {
     public string Name => "FakeLog";
     public FakeLogCollector LogCollector { get; init; }
-    public int MessageCount => LogCollector.Count;
+    public int EntryCount => LogCollector.Count;
 
     public Task<IEnumerable<IApplicationLogEntry>> GetEntriesAsync()
     {

--- a/Lombiq.Tests.UI/Models/FakeLoggerLogApplicationLog.cs
+++ b/Lombiq.Tests.UI/Models/FakeLoggerLogApplicationLog.cs
@@ -19,10 +19,7 @@ public sealed class FakeLoggerLogApplicationLog : IApplicationLog
     {
         var records = LogCollector.GetSnapshot();
 
-        return Task.FromResult(records.Select(record => (IApplicationLogEntry)new FakeLoggerApplicationLogEntry
-        {
-            LogRecord = record,
-        }));
+        return Task.FromResult(records.Select(record => (IApplicationLogEntry)new FakeLoggerApplicationLogEntry(record)));
     }
 
     public Task RemoveAsync()
@@ -32,7 +29,7 @@ public sealed class FakeLoggerLogApplicationLog : IApplicationLog
     }
 }
 
-public sealed class FakeLoggerApplicationLogEntry : IApplicationLogEntry
+public record FakeLoggerApplicationLogEntry(FakeLogRecord LogRecord) : IApplicationLogEntry
 {
     public LogLevel Level => LogRecord.Level;
     public EventId Id => LogRecord.Id;
@@ -40,7 +37,6 @@ public sealed class FakeLoggerApplicationLogEntry : IApplicationLogEntry
     public string Message => LogRecord.Message;
     public string Category => LogRecord.Category;
     public DateTimeOffset Timestamp => LogRecord.Timestamp;
-    public FakeLogRecord LogRecord { get; init; }
 
     public override string ToString() => FormatLogRecord(LogRecord);
 

--- a/Lombiq.Tests.UI/Models/FakeLoggerLogApplicationLog.cs
+++ b/Lombiq.Tests.UI/Models/FakeLoggerLogApplicationLog.cs
@@ -1,0 +1,53 @@
+using Lombiq.Tests.UI.Services;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Testing;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Lombiq.Tests.UI.Models;
+
+public sealed class FakeLoggerLogApplicationLog : IApplicationLog
+{
+    public string Name => "FakeLog";
+    public FakeLogCollector LogCollector { get; init; }
+    public int MessageCount => LogCollector.Count;
+
+    public Task<IEnumerable<IApplicationLogEntry>> GetEntriesAsync()
+    {
+        var records = LogCollector.GetSnapshot();
+
+        return Task.FromResult(records.Select(record => (IApplicationLogEntry)new FakeLoggerApplicationLogEntry
+        {
+            Level = record.Level,
+            Id = record.Id,
+            Exception = record.Exception,
+            Message = record.Message,
+            Category = record.Category,
+            Timestamp = record.Timestamp,
+            LogRecord = record,
+        }));
+    }
+
+    public Task RemoveAsync()
+    {
+        LogCollector.Clear();
+        return Task.CompletedTask;
+    }
+}
+
+public sealed class FakeLoggerApplicationLogEntry : IApplicationLogEntry
+{
+    public LogLevel Level { get; init; }
+    public EventId Id { get; init; }
+    public Exception Exception { get; init; }
+    public string Message { get; init; }
+    public string Category { get; init; }
+    public DateTimeOffset Timestamp { get; init; }
+    public FakeLogRecord LogRecord { get; init; }
+
+    public override string ToString() =>
+        $"{Timestamp:yyyy-MM-dd HH:mm:ss.fff} [{Level}] {Category}: {Message}" +
+        (Exception != null ? Exception.ToString() : string.Empty);
+}

--- a/Lombiq.Tests.UI/Models/FakeLoggerLogApplicationLog.cs
+++ b/Lombiq.Tests.UI/Models/FakeLoggerLogApplicationLog.cs
@@ -1,3 +1,4 @@
+using Lombiq.HelpfulLibraries.Common.Utilities;
 using Lombiq.Tests.UI.Services;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Testing;
@@ -20,12 +21,6 @@ public sealed class FakeLoggerLogApplicationLog : IApplicationLog
 
         return Task.FromResult(records.Select(record => (IApplicationLogEntry)new FakeLoggerApplicationLogEntry
         {
-            Level = record.Level,
-            Id = record.Id,
-            Exception = record.Exception,
-            Message = record.Message,
-            Category = record.Category,
-            Timestamp = record.Timestamp,
             LogRecord = record,
         }));
     }
@@ -39,15 +34,17 @@ public sealed class FakeLoggerLogApplicationLog : IApplicationLog
 
 public sealed class FakeLoggerApplicationLogEntry : IApplicationLogEntry
 {
-    public LogLevel Level { get; init; }
-    public EventId Id { get; init; }
-    public Exception Exception { get; init; }
-    public string Message { get; init; }
-    public string Category { get; init; }
-    public DateTimeOffset Timestamp { get; init; }
+    public LogLevel Level => LogRecord.Level;
+    public EventId Id => LogRecord.Id;
+    public Exception Exception => LogRecord.Exception;
+    public string Message => LogRecord.Message;
+    public string Category => LogRecord.Category;
+    public DateTimeOffset Timestamp => LogRecord.Timestamp;
     public FakeLogRecord LogRecord { get; init; }
 
-    public override string ToString() =>
-        $"{Timestamp:yyyy-MM-dd HH:mm:ss.fff} [{Level}] {Category}: {Message}" +
-        (Exception != null ? Exception.ToString() : string.Empty);
+    public override string ToString() => FormatLogRecord(LogRecord);
+
+    public static string FormatLogRecord(FakeLogRecord record) =>
+        StringHelper.CreateInvariant($"{record.Timestamp:yyyy-MM-dd HH:mm:ss.fff} [{record.Level}] {record.Category}: {record.Message}") +
+        (record.Exception != null ? record.Exception.ToString() : string.Empty);
 }

--- a/Lombiq.Tests.UI/SecurityScanning/OrchardCoreUITestExecutorConfigurationExtensions.cs
+++ b/Lombiq.Tests.UI/SecurityScanning/OrchardCoreUITestExecutorConfigurationExtensions.cs
@@ -1,4 +1,5 @@
 using Lombiq.Tests.UI.Extensions;
+using Lombiq.Tests.UI.Helpers;
 using Lombiq.Tests.UI.Services;
 using Lombiq.Tests.UI.Shortcuts.Controllers;
 using Microsoft.Extensions.Logging;
@@ -57,9 +58,6 @@ public static class OrchardCoreUITestExecutorConfigurationExtensions
             // Thrown from Microsoft.AspNetCore.Authentication.AuthenticationService.ChallengeAsync() when ZAP sends
             // invalid authentication challenges.
             "System.InvalidOperationException: No authentication handler is registered for the scheme",
-            // These errors frequently happen during UI testing when using Azure Blob Storage for media storage. They're
-            // harmless, though.
-            "Error deleting cache folder",
         };
 
         permittedErrorLinePatterns.AddRange(additionalPermittedErrorLinePatterns);
@@ -67,6 +65,7 @@ public static class OrchardCoreUITestExecutorConfigurationExtensions
         return app =>
             app.LogsShouldNotContainAsync(logEntry =>
                 !permittedErrorLinePatterns.Any(pattern =>
-                    Regex.IsMatch(logEntry.ToString(), pattern, RegexOptions.IgnoreCase | RegexOptions.Compiled)));
+                    Regex.IsMatch(logEntry.ToString(), pattern, RegexOptions.IgnoreCase | RegexOptions.Compiled)) &&
+                AppLogAssertionHelper.NotMediaCacheEntries(logEntry));
     }
 }

--- a/Lombiq.Tests.UI/SecurityScanning/OrchardCoreUITestExecutorConfigurationExtensions.cs
+++ b/Lombiq.Tests.UI/SecurityScanning/OrchardCoreUITestExecutorConfigurationExtensions.cs
@@ -66,6 +66,7 @@ public static class OrchardCoreUITestExecutorConfigurationExtensions
             app.LogsShouldNotContainAsync(logEntry =>
                 !permittedErrorLinePatterns.Any(pattern =>
                     Regex.IsMatch(logEntry.ToString(), pattern, RegexOptions.IgnoreCase | RegexOptions.Compiled)) &&
-                AppLogAssertionHelper.NotMediaCacheEntries(logEntry));
+                AppLogAssertionHelper.NotMediaCacheEntries(logEntry) &&
+                logEntry.Level >= LogLevel.Error);
     }
 }

--- a/Lombiq.Tests.UI/SecurityScanning/OrchardCoreUITestExecutorConfigurationExtensions.cs
+++ b/Lombiq.Tests.UI/SecurityScanning/OrchardCoreUITestExecutorConfigurationExtensions.cs
@@ -1,0 +1,72 @@
+using Lombiq.Tests.UI.Extensions;
+using Lombiq.Tests.UI.Services;
+using Lombiq.Tests.UI.Shortcuts.Controllers;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+
+namespace Lombiq.Tests.UI.SecurityScanning;
+
+public static class OrchardCoreUITestExecutorConfigurationExtensions
+{
+    /// <summary>
+    /// Sets the <see cref="OrchardCoreUITestExecutorConfiguration.AssertAppLogsAsync"/> to the output of <see
+    /// cref="CreateAppLogAssertionForSecurityScan"/> so it accepts errors in the log caused by the security scanning.
+    /// </summary>
+    public static OrchardCoreUITestExecutorConfiguration UseAssertAppLogsForSecurityScan(
+        this OrchardCoreUITestExecutorConfiguration configuration,
+        params string[] additionalPermittedErrorLinePatterns)
+    {
+        configuration.AssertAppLogsAsync = CreateAppLogAssertionForSecurityScan(additionalPermittedErrorLinePatterns);
+
+        return configuration;
+    }
+
+    /// <summary>
+    /// Similar to <see cref="OrchardCoreUITestExecutorConfiguration.AssertAppLogsCanContainCacheFolderErrorsAsync"/>,
+    /// but also permits certain <see cref="LogLevel.Error"/> log messages which represent correct reactions to
+    /// incorrect or malicious user behavior during a security scan.
+    /// </summary>
+    public static Func<IWebApplicationInstance, Task> CreateAppLogAssertionForSecurityScan(params string[] additionalPermittedErrorLinePatterns)
+    {
+        var permittedErrorLinePatterns = new List<string>
+        {
+            // The model binding will throw FormatException exception with this text during ZAP active scan, when the
+            // bot tries to send malicious query strings or POST data that doesn't fit the types expected by the model.
+            // This is correct, safe behavior and should be logged in production.
+            "is not a valid value for Boolean",
+            "An unhandled exception has occurred while executing the request. System.FormatException: any",
+            "System.FormatException: The input string '[\\S\\s]+' was not in a correct format.",
+            "System.FormatException: The input string 'any",
+            // Happens when the static file middleware tries to access a path that doesn't exist or access a file as a
+            // directory. Presumably this is an attempt to access protected files using source path manipulation. This
+            // is handled by ASP.NET Core and there is nothing for us to worry about.
+            "System.IO.IOException: Not a directory",
+            "System.IO.IOException: The filename, directory name, or volume label syntax is incorrect",
+            "System.IO.DirectoryNotFoundException: Could not find a part of the path",
+            // This happens when a request's model contains a dictionary and a key is missing. While this can be a
+            // legitimate application error, during a security scan it's more likely the result of an incomplete
+            // artificially constructed request. So the means the ASP.NET Core model binding is working as intended.
+            "An unhandled exception has occurred while executing the request. System.ArgumentNullException: Value cannot be null. (Parameter 'key')",
+            // One way to verify correct error handling is to navigate to ~/Lombiq.Tests.UI.Shortcuts/Error/Index, which
+            // always throws an exception. This also gets logged but it's expected, so it should be ignored.
+            ErrorController.ExceptionMessage,
+            // Thrown from Microsoft.AspNetCore.Authentication.AuthenticationService.ChallengeAsync() when ZAP sends
+            // invalid authentication challenges.
+            "System.InvalidOperationException: No authentication handler is registered for the scheme",
+            // These errors frequently happen during UI testing when using Azure Blob Storage for media storage. They're
+            // harmless, though.
+            "Error deleting cache folder",
+        };
+
+        permittedErrorLinePatterns.AddRange(additionalPermittedErrorLinePatterns);
+
+        return app =>
+            app.LogsShouldNotContainAsync(logEntry =>
+                !permittedErrorLinePatterns.Any(pattern =>
+                    Regex.IsMatch(logEntry.ToString(), pattern, RegexOptions.IgnoreCase | RegexOptions.Compiled)));
+    }
+}

--- a/Lombiq.Tests.UI/SecurityScanning/SecurityScanningUITestContextExtensions.cs
+++ b/Lombiq.Tests.UI/SecurityScanning/SecurityScanningUITestContextExtensions.cs
@@ -57,9 +57,9 @@ public static class SecurityScanningUITestContextExtensions
     /// This extension method makes changes to the normal configuration of the test to be more suited for CI operation.
     /// It changes the <see cref="UITestContext.Configuration"/> to not do any retries because this is a long running
     /// test. It also replaces the app log assertion logic with the specialized version for security scans, <see
-    /// cref="OrchardCoreUITestExecutorConfiguration.UseAssertAppLogsForSecurityScan"/>. The scan is configured t
-    /// ignore the admin dashboard, optionally log in as admin, and use the provided time limits for the "active scan"
-    /// portion of the security scan.
+    /// cref="OrchardCoreUITestExecutorConfigurationExtensions.UseAssertAppLogsForSecurityScan"/>. The scan is
+    /// configured to ignore the admin dashboard, optionally log in as admin, and use the provided time limits for the
+    /// "active scan" portion of the security scan.
     /// </para></remarks>
     public static Task RunAndConfigureAndAssertFullSecurityScanForContinuousIntegrationAsync(
         this UITestContext context,

--- a/Lombiq.Tests.UI/Services/IApplicationLog.cs
+++ b/Lombiq.Tests.UI/Services/IApplicationLog.cs
@@ -1,0 +1,69 @@
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Lombiq.Tests.UI.Services;
+
+/// <summary>
+/// An abstraction over a log, be it in the form of a file or something else.
+/// </summary>
+public interface IApplicationLog
+{
+    /// <summary>
+    /// Gets the name of the log, such as the file name.
+    /// </summary>
+    string Name { get; }
+
+    /// <summary>
+    /// Gets the number of messages in the log.
+    /// </summary>
+    int MessageCount { get; }
+
+    /// <summary>
+    /// Returns the content of the log, in case of log files reads the file contents.
+    /// </summary>
+    /// <returns>The contents.</returns>
+    Task<IEnumerable<IApplicationLogMessage>> GetContentAsync();
+
+    /// <summary>
+    /// Removes the log if possible.
+    /// </summary>
+    void Remove();
+}
+
+/// <summary>
+/// An abstraction over a log message.
+/// </summary>
+public interface IApplicationLogMessage
+{
+    /// <summary>
+    /// Gets the level of the log message, like <see cref="LogLevel.Error"/> or <see cref="LogLevel.Warning"/>.
+    /// </summary>
+    LogLevel Level { get; }
+
+    /// <summary>
+    /// Gets the ID that uniquely identifies the log message.
+    /// </summary>
+    EventId Id { get; }
+
+    /// <summary>
+    /// Gets the exception associated with the log message, if any.
+    /// </summary>
+    Exception Exception { get; }
+
+    /// <summary>
+    /// Gets the human-readable formatted log message.
+    /// </summary>
+    string Message { get; }
+
+    /// <summary>
+    /// Gets the category of the log message. This is the type parameter of <see cref="ILogger{TCategoryName}"/>.
+    /// </summary>
+    string Category { get; }
+
+    /// <summary>
+    /// Gets the timestamp of when the log message was created.
+    /// </summary>
+    DateTimeOffset Timestamp { get; }
+}

--- a/Lombiq.Tests.UI/Services/IApplicationLog.cs
+++ b/Lombiq.Tests.UI/Services/IApplicationLog.cs
@@ -24,18 +24,18 @@ public interface IApplicationLog
     /// Returns the content of the log, in case of log files reads the file contents.
     /// </summary>
     /// <returns>The contents.</returns>
-    Task<IEnumerable<IApplicationLogMessage>> GetContentAsync();
+    Task<IEnumerable<IApplicationLogEntry>> GetEntriesAsync();
 
     /// <summary>
     /// Removes the log if possible.
     /// </summary>
-    void Remove();
+    Task RemoveAsync();
 }
 
 /// <summary>
 /// An abstraction over a log message.
 /// </summary>
-public interface IApplicationLogMessage
+public interface IApplicationLogEntry
 {
     /// <summary>
     /// Gets the level of the log message, like <see cref="LogLevel.Error"/> or <see cref="LogLevel.Warning"/>.

--- a/Lombiq.Tests.UI/Services/IApplicationLog.cs
+++ b/Lombiq.Tests.UI/Services/IApplicationLog.cs
@@ -16,9 +16,9 @@ public interface IApplicationLog
     string Name { get; }
 
     /// <summary>
-    /// Gets the number of messages in the log.
+    /// Gets the number of log entries in the log.
     /// </summary>
-    int MessageCount { get; }
+    int EntryCount { get; }
 
     /// <summary>
     /// Returns the content of the log, in case of log files reads the file contents.
@@ -33,22 +33,22 @@ public interface IApplicationLog
 }
 
 /// <summary>
-/// An abstraction over a log message.
+/// An abstraction over a log entries.
 /// </summary>
 public interface IApplicationLogEntry
 {
     /// <summary>
-    /// Gets the level of the log message, like <see cref="LogLevel.Error"/> or <see cref="LogLevel.Warning"/>.
+    /// Gets the level of the log entry, like <see cref="LogLevel.Error"/> or <see cref="LogLevel.Warning"/>.
     /// </summary>
     LogLevel Level { get; }
 
     /// <summary>
-    /// Gets the ID that uniquely identifies the log message.
+    /// Gets the ID that uniquely identifies the log entry.
     /// </summary>
     EventId Id { get; }
 
     /// <summary>
-    /// Gets the exception associated with the log message, if any.
+    /// Gets the exception associated with the log entry, if any.
     /// </summary>
     Exception Exception { get; }
 
@@ -58,12 +58,12 @@ public interface IApplicationLogEntry
     string Message { get; }
 
     /// <summary>
-    /// Gets the category of the log message. This is the type parameter of <see cref="ILogger{TCategoryName}"/>.
+    /// Gets the category of the log entry. This is the type parameter of <see cref="ILogger{TCategoryName}"/>.
     /// </summary>
     string Category { get; }
 
     /// <summary>
-    /// Gets the timestamp of when the log message was created.
+    /// Gets the timestamp of when the log entry was created.
     /// </summary>
     DateTimeOffset Timestamp { get; }
 }

--- a/Lombiq.Tests.UI/Services/IWebApplicationInstance.cs
+++ b/Lombiq.Tests.UI/Services/IWebApplicationInstance.cs
@@ -44,16 +44,6 @@ public interface IWebApplicationInstance : IAsyncDisposable
     /// </summary>
     /// <returns>The collection of log names and their contents.</returns>
     IEnumerable<IApplicationLog> GetLogs(CancellationToken cancellationToken = default);
-
-    /// <summary>
-    /// Get service of type <typeparamref name="TService"/>.
-    /// </summary>
-    /// <typeparam name="TService">The type of service object to get.</typeparam>
-    /// <returns>A service object of type <typeparamref name="TService"/>.</returns>
-    /// <exception cref="InvalidOperationException">
-    /// There is no service of type <typeparamref name="TService"/>.
-    /// </exception>
-    TService GetRequiredService<TService>();
 }
 
 /// <summary>

--- a/Lombiq.Tests.UI/Services/IWebApplicationInstance.cs
+++ b/Lombiq.Tests.UI/Services/IWebApplicationInstance.cs
@@ -43,5 +43,5 @@ public interface IWebApplicationInstance : IAsyncDisposable
     /// Reads all the application logs.
     /// </summary>
     /// <returns>The collection of log names and their contents.</returns>
-    IEnumerable<IApplicationLog> GetLogs(CancellationToken cancellationToken = default);
+    Task<IEnumerable<IApplicationLog>> GetLogsAsync(CancellationToken cancellationToken = default);
 }

--- a/Lombiq.Tests.UI/Services/IWebApplicationInstance.cs
+++ b/Lombiq.Tests.UI/Services/IWebApplicationInstance.cs
@@ -45,25 +45,3 @@ public interface IWebApplicationInstance : IAsyncDisposable
     /// <returns>The collection of log names and their contents.</returns>
     IEnumerable<IApplicationLog> GetLogs(CancellationToken cancellationToken = default);
 }
-
-/// <summary>
-/// An abstraction over a log, be it in the form of a file or something else.
-/// </summary>
-public interface IApplicationLog
-{
-    /// <summary>
-    /// Gets the name of the log, such as the file name.
-    /// </summary>
-    string Name { get; }
-
-    /// <summary>
-    /// Returns the content of the log, in case of log files reads the file contents.
-    /// </summary>
-    /// <returns>The contents.</returns>
-    Task<string> GetContentAsync();
-
-    /// <summary>
-    /// Removes the log if possible.
-    /// </summary>
-    void Remove();
-}

--- a/Lombiq.Tests.UI/Services/OrchardCoreHosting/OrchardApplicationFactory.cs
+++ b/Lombiq.Tests.UI/Services/OrchardCoreHosting/OrchardApplicationFactory.cs
@@ -9,10 +9,8 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 using NLog;
-using NLog.Web;
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using YesSql;
@@ -73,19 +71,9 @@ public sealed class OrchardApplicationFactory<TStartup> : WebApplicationFactory<
     {
         builder
             .ConfigureTestServices(ConfigureTestServices)
-            .ConfigureLogging((context, loggingBuilder) =>
-            {
-                var environment = context.HostingEnvironment;
-                var nLogConfig = Path.Combine(environment.ContentRootPath, "NLog.config");
-                var factory = new LogFactory()
-                    .Setup()
-                    .LoadConfigurationFromFile(nLogConfig)
-                    .LogFactory;
-
-                factory.Configuration.Variables["configDir"] = environment.ContentRootPath;
-
-                loggingBuilder.AddNLogWeb(factory, new NLogAspNetCoreOptions { ReplaceLoggerFactory = true });
-            });
+            // NLog, if used, will put log files into configDir. Not setting this would use the default, which would be
+            // App_Data/App_Data/logs.
+            .ConfigureLogging((context, _) => LogManager.Configuration.Variables["configDir"] = context.HostingEnvironment.ContentRootPath);
 
         _configuration?.Invoke(builder);
     }

--- a/Lombiq.Tests.UI/Services/OrchardCoreHosting/OrchardApplicationFactory.cs
+++ b/Lombiq.Tests.UI/Services/OrchardCoreHosting/OrchardApplicationFactory.cs
@@ -71,7 +71,8 @@ public sealed class OrchardApplicationFactory<TStartup> : WebApplicationFactory<
 
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {
-        builder.ConfigureTestServices(ConfigureTestServices)
+        builder
+            .ConfigureTestServices(ConfigureTestServices)
             .ConfigureLogging((context, loggingBuilder) =>
             {
                 var environment = context.HostingEnvironment;

--- a/Lombiq.Tests.UI/Services/OrchardCoreHosting/OrchardApplicationFactory.cs
+++ b/Lombiq.Tests.UI/Services/OrchardCoreHosting/OrchardApplicationFactory.cs
@@ -84,12 +84,13 @@ public sealed class OrchardApplicationFactory<TStartup> : WebApplicationFactory<
                 .LastOrDefault(descriptor => descriptor.ServiceType == typeof(OrchardCoreBuilder))?
                 .ImplementationInstance as OrchardCoreBuilder
                 ?? throw new InvalidOperationException(
-                    "Please call WebApplicationBuilder.Services.AddOrchardCms() in your Program.cs!");
+                    "Please call WebApplicationBuilder.Services.AddOrchardCms() in your Program.cs.");
         var configuration = services
                 .LastOrDefault(descriptor => descriptor.ServiceType == typeof(ConfigurationManager))?
                 .ImplementationInstance as ConfigurationManager
                 ?? throw new InvalidOperationException(
-                    $"Please add {nameof(ConfigurationManager)} instance to WebApplicationBuilder.Services in your Program.cs!");
+                    $"Please register the {nameof(ConfigurationManager)} instance in the Service Collection in your " +
+                    "Program.cs, following the documentation.");
 
         _configureOrchard?.Invoke(configuration, builder);
 

--- a/Lombiq.Tests.UI/Services/OrchardCoreInstance.cs
+++ b/Lombiq.Tests.UI/Services/OrchardCoreInstance.cs
@@ -130,9 +130,6 @@ public sealed class OrchardCoreInstance<TEntryPoint> : IWebApplicationInstance
             : [];
     }
 
-    public TService GetRequiredService<TService>() =>
-        _orchardApplication.Services.GetRequiredService<TService>();
-
     public async ValueTask DisposeAsync()
     {
         if (_isDisposed) return;

--- a/Lombiq.Tests.UI/Services/OrchardCoreInstance.cs
+++ b/Lombiq.Tests.UI/Services/OrchardCoreInstance.cs
@@ -116,19 +116,21 @@ public sealed class OrchardCoreInstance<TEntryPoint> : IWebApplicationInstance
         return TakeSnapshotInnerAsync(snapshotDirectoryPath);
     }
 
-    public IEnumerable<IApplicationLog> GetLogs(CancellationToken cancellationToken = default)
+    public Task<IEnumerable<IApplicationLog>> GetLogsAsync(CancellationToken cancellationToken = default)
     {
         if (Services.GetService<FakeLogCollector>() is { } logCollector)
         {
-            return [
-                new ApplicationLog
+            return Task.FromResult(
+                new IApplicationLog[]
                 {
-                    LogCollector = logCollector,
-                },
-            ];
+                    new FakeLoggerLogApplicationLog
+                    {
+                        LogCollector = logCollector,
+                    },
+                }.AsEnumerable());
         }
 
-        return [];
+        return Task.FromResult(Enumerable.Empty<IApplicationLog>());
     }
 
     public async ValueTask DisposeAsync()
@@ -176,7 +178,6 @@ public sealed class OrchardCoreInstance<TEntryPoint> : IWebApplicationInstance
                 .ConfigureLogging(loggingBuilder => loggingBuilder.AddFakeLogging(options =>
                 {
                     options.CollectRecordsForDisabledLogLevels = false;
-                    options.FilteredLevels.Add(LogLevel.Warning);
                     options.FilteredLevels.Add(LogLevel.Error);
                     options.OutputSink += message => _testOutputHelper.WriteLine(message);
                 })),
@@ -223,44 +224,4 @@ public sealed class OrchardCoreInstance<TEntryPoint> : IWebApplicationInstance
 
     private OrchardCoreAppStartContext CreateAppStartContext() =>
         new(_contentRootPath, _url, OrchardCoreInstanceCounter.PortLeases);
-
-    private sealed class ApplicationLog : IApplicationLog
-    {
-        public string Name => "FakeLog";
-        public FakeLogCollector LogCollector { get; init; }
-        public int MessageCount => LogCollector.Count;
-
-        public Task<IEnumerable<IApplicationLogMessage>> GetContentAsync()
-        {
-            var records = LogCollector.GetSnapshot();
-
-            return Task.FromResult(records.Select(record => (IApplicationLogMessage)new ApplicationLogMessage
-            {
-                Level = record.Level,
-                Id = record.Id,
-                Exception = record.Exception,
-                Message = record.Message,
-                Category = record.Category,
-                Timestamp = record.Timestamp,
-                LogRecord = record,
-            }));
-        }
-
-        public void Remove() => LogCollector.Clear();
-    }
-
-    private sealed class ApplicationLogMessage : IApplicationLogMessage
-    {
-        public LogLevel Level { get; init; }
-        public EventId Id { get; init; }
-        public Exception Exception { get; init; }
-        public string Message { get; init; }
-        public string Category { get; init; }
-        public DateTimeOffset Timestamp { get; init; }
-        public FakeLogRecord LogRecord { get; init; }
-
-        public override string ToString() =>
-            $"{Timestamp:yyyy-MM-dd HH:mm:ss.fff} [{Level}] {Category}: {Message}" +
-            (Exception != null ? Exception.ToString() : string.Empty);
-    }
 }

--- a/Lombiq.Tests.UI/Services/OrchardCoreInstance.cs
+++ b/Lombiq.Tests.UI/Services/OrchardCoreInstance.cs
@@ -180,6 +180,8 @@ public sealed class OrchardCoreInstance<TEntryPoint> : IWebApplicationInstance
                 {
                     options.CollectRecordsForDisabledLogLevels = false;
                     options.FilteredLevels.Add(LogLevel.Error);
+                    options.FilteredLevels.Add(LogLevel.Critical);
+                    options.OutputFormatter = FakeLoggerApplicationLogEntry.FormatLogRecord;
                     options.OutputSink += message => _testOutputHelper.WriteLine(message);
 
                     _configuration.AfterFakeLoggingConfiguration?.Invoke(CreateAppStartContext(), options);

--- a/Lombiq.Tests.UI/Services/OrchardCoreInstance.cs
+++ b/Lombiq.Tests.UI/Services/OrchardCoreInstance.cs
@@ -223,6 +223,8 @@ public sealed class OrchardCoreInstance<TEntryPoint> : IWebApplicationInstance
             .InvokeAsync<BeforeTakeSnapshotHandler>(handler => handler(CreateAppStartContext(), snapshotDirectoryPath));
 
         FileSystem.CopyDirectory(_contentRootPath, snapshotDirectoryPath, overwrite: true);
+
+        await ResumeAsync();
     }
 
     private OrchardCoreAppStartContext CreateAppStartContext() =>

--- a/Lombiq.Tests.UI/Services/OrchardCoreInstance.cs
+++ b/Lombiq.Tests.UI/Services/OrchardCoreInstance.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Testing;
 using Microsoft.VisualBasic.FileIO;
 using System;
 using System.Collections.Generic;
@@ -117,17 +118,17 @@ public sealed class OrchardCoreInstance<TEntryPoint> : IWebApplicationInstance
 
     public IEnumerable<IApplicationLog> GetLogs(CancellationToken cancellationToken = default)
     {
-        var logFolderPath = Path.Combine(_contentRootPath, "App_Data", "logs");
-        return Directory.Exists(logFolderPath)
-            ? Directory
-                .EnumerateFiles(logFolderPath, "*.log")
-                .Select(filePath => (IApplicationLog)new ApplicationLog
+        if (Services.GetService<FakeLogCollector>() is { } logCollector)
+        {
+            return [
+                new ApplicationLog
                 {
-                    Name = Path.GetFileName(filePath),
-                    FullName = Path.GetFullPath(filePath),
-                    ContentLoader = () => GetFileContentAsync(filePath, cancellationToken),
-                })
-            : [];
+                    LogCollector = logCollector,
+                },
+            ];
+        }
+
+        return [];
     }
 
     public async ValueTask DisposeAsync()
@@ -206,13 +207,6 @@ public sealed class OrchardCoreInstance<TEntryPoint> : IWebApplicationInstance
             .InvokeAsync<AfterAppStopHandler>(handler => handler(CreateAppStartContext()));
     }
 
-    private static async Task<string> GetFileContentAsync(string filePath, CancellationToken cancellationToken)
-    {
-        await using var fileStream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
-        using var streamReader = new StreamReader(fileStream);
-        return await streamReader.ReadToEndAsync(cancellationToken);
-    }
-
     private async Task TakeSnapshotInnerAsync(string snapshotDirectoryPath)
     {
         await PauseAsync();
@@ -232,15 +226,41 @@ public sealed class OrchardCoreInstance<TEntryPoint> : IWebApplicationInstance
 
     private sealed class ApplicationLog : IApplicationLog
     {
-        public string Name { get; init; }
-        public string FullName { get; init; }
-        public Func<Task<string>> ContentLoader { get; init; }
+        public string Name => "FakeLog";
+        public FakeLogCollector LogCollector { get; init; }
+        public int MessageCount => LogCollector.Count;
 
-        public Task<string> GetContentAsync() => ContentLoader();
-
-        public void Remove()
+        public Task<IEnumerable<IApplicationLogMessage>> GetContentAsync()
         {
-            if (File.Exists(FullName)) File.Delete(FullName);
+            var records = LogCollector.GetSnapshot();
+
+            return Task.FromResult(records.Select(record => (IApplicationLogMessage)new ApplicationLogMessage
+            {
+                Level = record.Level,
+                Id = record.Id,
+                Exception = record.Exception,
+                Message = record.Message,
+                Category = record.Category,
+                Timestamp = record.Timestamp,
+                LogRecord = record,
+            }));
         }
+
+        public void Remove() => LogCollector.Clear();
+    }
+
+    private sealed class ApplicationLogMessage : IApplicationLogMessage
+    {
+        public LogLevel Level { get; init; }
+        public EventId Id { get; init; }
+        public Exception Exception { get; init; }
+        public string Message { get; init; }
+        public string Category { get; init; }
+        public DateTimeOffset Timestamp { get; init; }
+        public FakeLogRecord LogRecord { get; init; }
+
+        public override string ToString() =>
+            $"{Timestamp:yyyy-MM-dd HH:mm:ss.fff} [{Level}] {Category}: {Message}" +
+            (Exception != null ? Exception.ToString() : string.Empty);
     }
 }

--- a/Lombiq.Tests.UI/Services/OrchardCoreInstance.cs
+++ b/Lombiq.Tests.UI/Services/OrchardCoreInstance.cs
@@ -9,7 +9,6 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Logging.Testing;
 using Microsoft.VisualBasic.FileIO;
 using System;
 using System.Collections.Generic;

--- a/Lombiq.Tests.UI/Services/OrchardCoreInstance.cs
+++ b/Lombiq.Tests.UI/Services/OrchardCoreInstance.cs
@@ -22,14 +22,15 @@ using Xunit.Abstractions;
 namespace Lombiq.Tests.UI.Services;
 
 public delegate Task BeforeAppStartHandler(OrchardCoreAppStartContext context, InstanceCommandLineArgumentsBuilder arguments);
+public delegate void AfterFakeLoggingConfigurationHandler(OrchardCoreAppStartContext context, FakeLogCollectorOptions fakeLogCollectorOptions);
 public delegate Task AfterAppStopHandler(OrchardCoreAppStartContext context);
-
 public delegate Task BeforeTakeSnapshotHandler(OrchardCoreAppStartContext context, string snapshotDirectoryPath);
 
 public class OrchardCoreConfiguration
 {
     public string SnapshotDirectoryPath { get; set; }
     public BeforeAppStartHandler BeforeAppStart { get; set; }
+    public AfterFakeLoggingConfigurationHandler AfterFakeLoggingConfiguration { get; set; }
     public AfterAppStopHandler AfterAppStop { get; set; }
     public BeforeTakeSnapshotHandler BeforeTakeSnapshot { get; set; }
     public int StartCount { get; internal set; }
@@ -180,6 +181,8 @@ public sealed class OrchardCoreInstance<TEntryPoint> : IWebApplicationInstance
                     options.CollectRecordsForDisabledLogLevels = false;
                     options.FilteredLevels.Add(LogLevel.Error);
                     options.OutputSink += message => _testOutputHelper.WriteLine(message);
+
+                    _configuration.AfterFakeLoggingConfiguration?.Invoke(CreateAppStartContext(), options);
                 })),
             (configuration, orchardBuilder) => orchardBuilder
                 .ConfigureUITesting(configuration, enableShortcutsDuringUITesting: true));

--- a/Lombiq.Tests.UI/Services/OrchardCoreInstance.cs
+++ b/Lombiq.Tests.UI/Services/OrchardCoreInstance.cs
@@ -8,6 +8,8 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Testing;
 using Microsoft.VisualBasic.FileIO;
 using System;
 using System.Collections.Generic;
@@ -56,6 +58,7 @@ public sealed class OrchardCoreInstance<TEntryPoint> : IWebApplicationInstance
     private readonly OrchardCoreConfiguration _configuration;
     private readonly string _contextId;
     private readonly ITestOutputHelper _testOutputHelper;
+
     private string _contentRootPath;
     private bool _isDisposed;
     private OrchardApplicationFactory<TEntryPoint> _orchardApplication;
@@ -172,7 +175,14 @@ public sealed class OrchardCoreInstance<TEntryPoint> : IWebApplicationInstance
             builder => builder
                 .UseContentRoot(_contentRootPath)
                 .UseWebRoot(Path.Combine(_contentRootPath, "wwwroot"))
-                .UseEnvironment(Environments.Development),
+                .UseEnvironment(Environments.Development)
+                .ConfigureLogging(loggingBuilder => loggingBuilder.AddFakeLogging(options =>
+                {
+                    options.CollectRecordsForDisabledLogLevels = false;
+                    options.FilteredLevels.Add(LogLevel.Warning);
+                    options.FilteredLevels.Add(LogLevel.Error);
+                    options.OutputSink += message => _testOutputHelper.WriteLine(message);
+                })),
             (configuration, orchardBuilder) => orchardBuilder
                 .ConfigureUITesting(configuration, enableShortcutsDuringUITesting: true));
 

--- a/Lombiq.Tests.UI/Services/OrchardCoreUITestExecutorConfiguration.cs
+++ b/Lombiq.Tests.UI/Services/OrchardCoreUITestExecutorConfiguration.cs
@@ -200,7 +200,7 @@ public class OrchardCoreUITestExecutorConfiguration
         catch (Exception)
         {
             log("Application logs: " + Environment.NewLine);
-            log(await instance.GetLogOutputAsync());
+            log(await instance.GetLogContentsAsync());
 
             throw;
         }

--- a/Lombiq.Tests.UI/Services/OrchardCoreUITestExecutorConfiguration.cs
+++ b/Lombiq.Tests.UI/Services/OrchardCoreUITestExecutorConfiguration.cs
@@ -36,8 +36,8 @@ public class OrchardCoreUITestExecutorConfiguration
         app => app.LogsShouldNotContainAsync(logEntry =>
             // These errors frequently happen during UI testing when using Azure Blob Storage for media storage. They're
             // harmless, though.
-            logEntry.Category == "OrchardCore.Media.Core.DefaultMediaFileStoreCacheFileProvider" &&
-            logEntry.Message.StartsWithOrdinalIgnoreCase("Error deleting cache folder"));
+            logEntry.Category != "OrchardCore.Media.Core.DefaultMediaFileStoreCacheFileProvider" ||
+            !logEntry.Message.StartsWithOrdinalIgnoreCase("Error deleting cache folder"));
 
     public static readonly Action<IEnumerable<LogEntry>> AssertBrowserLogIsEmpty =
         logEntries => logEntries.ShouldNotContain(

--- a/Lombiq.Tests.UI/Services/OrchardCoreUITestExecutorConfiguration.cs
+++ b/Lombiq.Tests.UI/Services/OrchardCoreUITestExecutorConfiguration.cs
@@ -1,4 +1,5 @@
 using Lombiq.Tests.UI.Extensions;
+using Lombiq.Tests.UI.Helpers;
 using Lombiq.Tests.UI.SecurityScanning;
 using Lombiq.Tests.UI.Services.GitHub;
 using OpenQA.Selenium;
@@ -33,11 +34,7 @@ public class OrchardCoreUITestExecutorConfiguration
         app.LogsShouldBeEmptyAsync();
 
     public static readonly Func<IWebApplicationInstance, Task> AssertAppLogsCanContainCacheFolderErrorsAsync =
-        app => app.LogsShouldNotContainAsync(logEntry =>
-            // These errors frequently happen during UI testing when using Azure Blob Storage for media storage. They're
-            // harmless, though.
-            logEntry.Category != "OrchardCore.Media.Core.DefaultMediaFileStoreCacheFileProvider" ||
-            !logEntry.Message.StartsWithOrdinalIgnoreCase("Error deleting cache folder"));
+        app => app.LogsShouldNotContainAsync(AppLogAssertionHelper.NotMediaCacheEntriesPredicate);
 
     public static readonly Action<IEnumerable<LogEntry>> AssertBrowserLogIsEmpty =
         logEntries => logEntries.ShouldNotContain(

--- a/Lombiq.Tests.UI/Services/OrchardCoreUITestExecutorConfiguration.cs
+++ b/Lombiq.Tests.UI/Services/OrchardCoreUITestExecutorConfiguration.cs
@@ -1,7 +1,6 @@
 using Lombiq.Tests.UI.Extensions;
 using Lombiq.Tests.UI.SecurityScanning;
 using Lombiq.Tests.UI.Services.GitHub;
-using Lombiq.Tests.UI.Shortcuts.Controllers;
 using OpenQA.Selenium;
 using Shouldly;
 using System;
@@ -30,21 +29,15 @@ public enum Browser
 
 public class OrchardCoreUITestExecutorConfiguration
 {
-    // These errors frequently happen during UI testing when using Azure Blob Storage for media storage.
-    // They're harmless, though.
-    private const string CacheFolderErrorPattern =
-        "OrchardCore.Media.Core.DefaultMediaFileStoreCacheFileProvider|ERROR|Error deleting cache folder";
-
     public static readonly Func<IWebApplicationInstance, Task> AssertAppLogsAreEmptyAsync = app =>
         app.LogsShouldBeEmptyAsync();
 
-    public static readonly Func<IWebApplicationInstance, Task> AssertAppLogsCanContainWarningsAsync =
-        app => app.LogsShouldBeEmptyAsync(canContainWarnings: true);
-
-    public static readonly Func<IWebApplicationInstance, Task> AssertAppLogsCanContainWarningsAndCacheFolderErrorsAsync =
-        app => app.LogsShouldBeEmptyAsync(
-            canContainWarnings: true,
-            permittedErrorLinePatterns: [CacheFolderErrorPattern]);
+    public static readonly Func<IWebApplicationInstance, Task> AssertAppLogsCanContainCacheFolderErrorsAsync =
+        app => app.LogsShouldNotContainAsync(logEntry =>
+            // These errors frequently happen during UI testing when using Azure Blob Storage for media storage. They're
+            // harmless, though.
+            logEntry.Category == "OrchardCore.Media.Core.DefaultMediaFileStoreCacheFileProvider" &&
+            logEntry.Message.StartsWithOrdinalIgnoreCase("Error deleting cache folder"));
 
     public static readonly Action<IEnumerable<LogEntry>> AssertBrowserLogIsEmpty =
         logEntries => logEntries.ShouldNotContain(
@@ -117,7 +110,7 @@ public class OrchardCoreUITestExecutorConfiguration
             ? intValue
             : Environment.ProcessorCount;
 
-    public Func<IWebApplicationInstance, Task> AssertAppLogsAsync { get; set; } = AssertAppLogsCanContainWarningsAsync;
+    public Func<IWebApplicationInstance, Task> AssertAppLogsAsync { get; set; } = AssertAppLogsCanContainCacheFolderErrorsAsync;
     public Action<IEnumerable<LogEntry>> AssertBrowserLog { get; set; } = AssertBrowserLogIsEmpty;
     public ITestOutputHelper TestOutputHelper { get; set; }
 
@@ -128,9 +121,8 @@ public class OrchardCoreUITestExecutorConfiguration
     /// </summary>
     /// <remarks>
     /// <para>
-    /// For this to properly work the build artifacts should be configured to contain the TestDumps folder (it can
-    /// also contain other folders but it must contain a folder called "TestDumps", e.g.: <c>+:TestDumps =&gt;
-    /// TestDumps</c>.
+    /// For this to properly work the build artifacts should be configured to contain the TestDumps folder (it can also
+    /// contain other folders but it must contain a folder called "TestDumps", e.g.: <c>+:TestDumps =&gt; TestDumps</c>.
     /// </para>
     /// </remarks>
     public bool ReportTeamCityMetadata { get; set; } =
@@ -229,55 +221,5 @@ public class OrchardCoreUITestExecutorConfiguration
 
             throw;
         }
-    }
-
-    /// <summary>
-    /// Sets the <see cref="AssertAppLogsAsync"/> to the output of <see cref="CreateAppLogAssertionForSecurityScan"/> so
-    /// it accepts errors in the log caused by the security scanning.
-    /// </summary>
-    public OrchardCoreUITestExecutorConfiguration UseAssertAppLogsForSecurityScan(params string[] additionalPermittedErrorLinePatterns)
-    {
-        AssertAppLogsAsync = CreateAppLogAssertionForSecurityScan(additionalPermittedErrorLinePatterns);
-
-        return this;
-    }
-
-    /// <summary>
-    /// Similar to <see cref="AssertAppLogsCanContainWarningsAsync"/>, but also permits certain <c>|ERROR</c> log
-    /// entries which represent correct reactions to incorrect or malicious user behavior during a security scan.
-    /// </summary>
-    public static Func<IWebApplicationInstance, Task> CreateAppLogAssertionForSecurityScan(params string[] additionalPermittedErrorLinePatterns)
-    {
-        var permittedErrorLinePatterns = new List<string>
-        {
-            // The model binding will throw FormatException exception with this text during ZAP active scan, when
-            // the bot tries to send malicious query strings or POST data that doesn't fit the types expected by the
-            // model. This is correct, safe behavior and should be logged in production.
-            "is not a valid value for Boolean",
-            "An unhandled exception has occurred while executing the request. System.FormatException: any",
-            "System.FormatException: The input string '[\\S\\s]+' was not in a correct format.",
-            "System.FormatException: The input string 'any",
-            // Happens when the static file middleware tries to access a path that doesn't exist or access a file as
-            // a directory. Presumably this is an attempt to access protected files using source path manipulation.
-            // This is handled by ASP.NET Core and there is nothing for us to worry about.
-            "System.IO.IOException: Not a directory",
-            "System.IO.IOException: The filename, directory name, or volume label syntax is incorrect",
-            "System.IO.DirectoryNotFoundException: Could not find a part of the path",
-            // This happens when a request's model contains a dictionary and a key is missing. While this can be a
-            // legitimate application error, during a security scan it's more likely the result of an incomplete
-            // artificially constructed request. So the means the ASP.NET Core model binding is working as intended.
-            "An unhandled exception has occurred while executing the request. System.ArgumentNullException: Value cannot be null. (Parameter 'key')",
-            // One way to verify correct error handling is to navigate to ~/Lombiq.Tests.UI.Shortcuts/Error/Index, which
-            // always throws an exception. This also gets logged but it's expected, so it should be ignored.
-            ErrorController.ExceptionMessage,
-            // Thrown from Microsoft.AspNetCore.Authentication.AuthenticationService.ChallengeAsync() when ZAP sends
-            // invalid authentication challenges.
-            "System.InvalidOperationException: No authentication handler is registered for the scheme",
-            CacheFolderErrorPattern,
-        };
-
-        permittedErrorLinePatterns.AddRange(additionalPermittedErrorLinePatterns);
-
-        return app => app.LogsShouldBeEmptyAsync(canContainWarnings: true, permittedErrorLinePatterns);
     }
 }

--- a/Lombiq.Tests.UI/Services/OrchardCoreUITestExecutorConfiguration.cs
+++ b/Lombiq.Tests.UI/Services/OrchardCoreUITestExecutorConfiguration.cs
@@ -185,38 +185,4 @@ public class OrchardCoreUITestExecutorConfiguration
     /// enabled in the app for these to work.
     /// </summary>
     public ShortcutsConfiguration ShortcutsConfiguration { get; set; } = new();
-
-    public async Task AssertAppLogsMaybeAsync(IWebApplicationInstance instance, Action<string> log)
-    {
-        if (instance == null || AssertAppLogsAsync == null) return;
-
-        try
-        {
-            await AssertAppLogsAsync(instance);
-        }
-        catch (Exception)
-        {
-            log("Application logs: " + Environment.NewLine);
-            log(await instance.GetLogContentsAsync());
-
-            throw;
-        }
-    }
-
-    public void AssertBrowserLogMaybe(IList<LogEntry> browserLogs, Action<string> log)
-    {
-        if (AssertBrowserLog == null) return;
-
-        try
-        {
-            AssertBrowserLog(browserLogs);
-        }
-        catch (Exception)
-        {
-            log("Browser logs: " + Environment.NewLine);
-            log(browserLogs.ToFormattedString());
-
-            throw;
-        }
-    }
 }

--- a/Lombiq.Tests.UI/Services/RemoteInstance.cs
+++ b/Lombiq.Tests.UI/Services/RemoteInstance.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -15,7 +16,8 @@ public sealed class RemoteInstance : IWebApplicationInstance
 
     public Task<Uri> StartUpAsync() => Task.FromResult(_baseUri);
 
-    public IEnumerable<IApplicationLog> GetLogs(CancellationToken cancellationToken = default) => [];
+    public Task<IEnumerable<IApplicationLog>> GetLogsAsync(CancellationToken cancellationToken = default) =>
+        Task.FromResult(Enumerable.Empty<IApplicationLog>());
     public TService GetRequiredService<TService>() => throw new NotSupportedException();
     public Task PauseAsync() => throw new NotSupportedException();
     public Task ResumeAsync() => throw new NotSupportedException();

--- a/Lombiq.Tests.UI/Services/SynchronizingWebApplicationSnapshotManager.cs
+++ b/Lombiq.Tests.UI/Services/SynchronizingWebApplicationSnapshotManager.cs
@@ -46,7 +46,6 @@ public class SynchronizingWebApplicationSnapshotManager
 
             var result = await appInitializer();
             await result.Context.Application.TakeSnapshotAsync(_snapshotDirectoryPath);
-            await result.Context.Application.ResumeAsync();
 
             DebugHelper.WriteLineTimestamped("Finished snapshot.");
 

--- a/Lombiq.Tests.UI/Services/UITestContext.cs
+++ b/Lombiq.Tests.UI/Services/UITestContext.cs
@@ -219,9 +219,9 @@ public class UITestContext
     /// Clears the application and historic browser logs.
     /// </summary>
     /// <param name="cancellationToken">Optional cancellation token for reading the application logs.</param>
-    public void ClearLogs(CancellationToken cancellationToken = default)
+    public async Task ClearLogsAsync(CancellationToken cancellationToken = default)
     {
-        foreach (var log in Application.GetLogs(cancellationToken)) log.Remove();
+        foreach (var log in await Application.GetLogsAsync(cancellationToken)) await log.RemoveAsync();
         ClearHistoricBrowserLog();
     }
 


### PR DESCRIPTION
[OSOE-402](https://lombiq.atlassian.net/browse/OSOE-402)
Fixes #206

**To be added to the release notes on the next release:**

## Breaking changes in logging during UI tests

One of the implicit assertions that the UI Testing Toolbox does automatically is checking the Orchard Core application logs for any errors. By default, any error fails the test.

Previously, this relied on the tested web app using NLog for logging, and it parsed NLog log files. This not only required the app to use NLog over Serilog (that Orchard also supports out of the box) or any other logging framework, but it also depended on the structure of an otherwise freely configurable textual log format.

Now, the UI Testing Toolbox configures the app to use [`FakeLogger`](https://learn.microsoft.com/en-us/dotnet/api/microsoft.extensions.logging.testing.fakelogger) in addition to any logging framework it has set up, and uses it for assertions. `FakeLogger` not only doesn't need anything specific in the app, but it also lets you access and assert on log entries in a structured, statically typed way.

Using NLog is still supported, and log files will be included in the test dump. Any other logging framework is also supported, your app doesn't need to do anything special.

### What changed

- All log management methods are now async.
- Log assertions now don't happen on a string representing the whole log, but rather on `IApplicationLog` and `IApplicationLogEntry` instances.
- The `LogsShouldBeEmptyAsync` and `GetLogOutputAsync` methods have changed, see [the diff](https://github.com/Lombiq/UI-Testing-Toolbox/pull/419/files#diff-cf3bc5fe84fc8a945f13d316362a82540659e238e71462e8c37ad43509919ac8).
- `CreateAppLogAssertionForSecurityScan` and `CreateAppLogAssertionForSecurityScan` work the same but were moved into the `Lombiq.Tests.UI.SecurityScanning` namespace.
- A new `OrchardCoreConfiguration.AfterFakeLoggingConfiguration` event handler is exposed to change the default configuration of `FakeLogger`.
- `OrchardCoreUITestExecutorConfiguration.AssertAppLogsCanContainWarningsAsync` and `OrchardCoreUITestExecutorConfiguration.AssertAppLogsCanContainWarningsAndCacheFolderErrorsAsync` are no longer available. 

### How to adapt

- Use `OrchardCoreUITestExecutorConfiguration.AssertAppLogsCanContainCacheFolderErrorsAsync` instead of  `OrchardCoreUITestExecutorConfiguration.AssertAppLogsCanContainWarningsAndCacheFolderErrorsAsync` .
- `OrchardCoreUITestExecutorConfiguration.AssertAppLogsCanContainWarningsAsync` is not needed, since the new behavior is to not log warnings in the first place.
- The examples are updated in `Lombiq.Tests.UI.Samples.UITestBase`, see [the diff](https://github.com/Lombiq/UI-Testing-Toolbox/pull/419/files#diff-9576924746d4544c4ff5da0ea6aa77390c83a8548084a3eafb5c7a0ea840f8b1). Check them out if you have custom app log assertion code.

[OSOE-402]: https://lombiq.atlassian.net/browse/OSOE-402?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ