### PR TITLE
OSOE-921: Update Atata.WebDriverSetup package to v3.1.0 and enable Edge tests again

### DIFF
--- a/Lombiq.Tests.UI.Samples/Tests/BasicVisualVerificationTests.cs
+++ b/Lombiq.Tests.UI.Samples/Tests/BasicVisualVerificationTests.cs
@@ -55,8 +55,7 @@ public class BasicVisualVerificationTests : UITestBase
     // is the different rendering of text on each platform, but it can occur between different Linux distributions too.
     // Here: https://pandasauce.org/post/linux-fonts/ you can find a good summary about this from 2019, but still valid
     // in 2022.
-    // Temporarily not running Edge until https://github.com/atata-framework/atata-webdriversetup/issues/16 is fixed.
-    [Theory, Chrome]
+    [Theory, Chrome, Edge]
     public Task VerifyNavbar(Browser browser) =>
         ExecuteTestAfterSetupAsync(
             context =>

--- a/Lombiq.Tests.UI.Samples/Tests/MultiBrowserTests.cs
+++ b/Lombiq.Tests.UI.Samples/Tests/MultiBrowserTests.cs
@@ -23,9 +23,7 @@ public class MultiBrowserTests : UITestBase
 
     // First, let's see a test using Edge. While the default browser is Chrome if you don't set anything, all
     // ExecuteTest* methods can also accept a browser, if you want to use a different one.
-#pragma warning disable xUnit1004 // Test methods should not be skipped
-    [Fact(Skip = "Temporarily not running Edge until https://github.com/atata-framework/atata-webdriversetup/issues/16 is fixed.")]
-#pragma warning restore xUnit1004 // Test methods should not be skipped
+    [Fact]
     public Task AnonymousHomePageShouldExistWithEdge() =>
         ExecuteTestAfterSetupAsync(NavbarIsCorrect, Browser.Edge);
 
@@ -33,8 +31,7 @@ public class MultiBrowserTests : UITestBase
     // tests. [Chrome] and [Edge] are input parameters of the test, and thus in effect, you have now two tests:
     // AnonymousHomePageShouldExistMultiBrowser once with Chrome, and once with Edge. See here for more info:
     // https://andrewlock.net/creating-parameterised-tests-in-xunit-with-inlinedata-classdata-and-memberdata/.
-    // Temporarily not running Edge until https://github.com/atata-framework/atata-webdriversetup/issues/16 is fixed.
-    [Theory, Chrome]
+    [Theory, Chrome, Edge]
     public Task AnonymousHomePageShouldExistMultiBrowser(Browser browser) =>
         ExecuteTestAfterSetupAsync(NavbarIsCorrect, browser);
 

--- a/Lombiq.Tests.UI/Lombiq.Tests.UI.csproj
+++ b/Lombiq.Tests.UI/Lombiq.Tests.UI.csproj
@@ -69,7 +69,7 @@
     <PackageReference Include="Atata.Bootstrap" Version="3.0.0" />
     <PackageReference Include="Atata.HtmlValidation" Version="3.1.0" />
     <PackageReference Include="Atata.WebDriverExtras" Version="3.0.0" />
-    <PackageReference Include="Atata.WebDriverSetup" Version="2.14.0" />
+    <PackageReference Include="Atata.WebDriverSetup" Version="3.1.0" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.19.1" />
     <PackageReference Include="Ben.Demystifier" Version="0.4.1" />
     <PackageReference Include="Codeuctivity.ImageSharpCompare" Version="4.0.258" />


### PR DESCRIPTION
[OSOE-921](https://lombiq.atlassian.net/browse/OSOE-921)
Fixes #426

[OSOE-921]: https://lombiq.atlassian.net/browse/OSOE-921?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ