### PR TITLE
OSOE-663: Remove references to Internet Explorer in Lombiq.UITestingToolbox

### DIFF
--- a/Lombiq.Tests.UI/Attributes/InternetExplorerAttribute.cs
+++ b/Lombiq.Tests.UI/Attributes/InternetExplorerAttribute.cs
@@ -1,8 +1,0 @@
-using Lombiq.Tests.UI.Services;
-
-namespace Lombiq.Tests.UI.Attributes;
-
-public sealed class InternetExplorerAttribute : BrowserAttributeBase
-{
-    protected override Browser Browser => Browser.InternetExplorer;
-}

--- a/Lombiq.Tests.UI/CompatibilitySuppressions.xml
+++ b/Lombiq.Tests.UI/CompatibilitySuppressions.xml
@@ -22,4 +22,11 @@
     <Right>lib/net8.0/Lombiq.Tests.UI.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0011</DiagnosticId>
+    <Target>F:Lombiq.Tests.UI.Services.Browser.None</Target>
+    <Left>lib/net8.0/Lombiq.Tests.UI.dll</Left>
+    <Right>lib/net8.0/Lombiq.Tests.UI.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
 </Suppressions>

--- a/Lombiq.Tests.UI/CompatibilitySuppressions.xml
+++ b/Lombiq.Tests.UI/CompatibilitySuppressions.xml
@@ -1,0 +1,25 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- https://learn.microsoft.com/en-us/dotnet/fundamentals/package-validation/diagnostic-ids -->
+<Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <Suppression>
+    <DiagnosticId>CP0001</DiagnosticId>
+    <Target>T:Lombiq.Tests.UI.Attributes.InternetExplorerAttribute</Target>
+    <Left>lib/net8.0/Lombiq.Tests.UI.dll</Left>
+    <Right>lib/net8.0/Lombiq.Tests.UI.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>F:Lombiq.Tests.UI.Services.Browser.InternetExplorer</Target>
+    <Left>lib/net8.0/Lombiq.Tests.UI.dll</Left>
+    <Right>lib/net8.0/Lombiq.Tests.UI.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Lombiq.Tests.UI.Services.WebDriverFactory.CreateInternetExplorerDriverAsync(Lombiq.Tests.UI.Services.BrowserConfiguration,System.TimeSpan)</Target>
+    <Left>lib/net8.0/Lombiq.Tests.UI.dll</Left>
+    <Right>lib/net8.0/Lombiq.Tests.UI.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+</Suppressions>

--- a/Lombiq.Tests.UI/Docs/Tools.md
+++ b/Lombiq.Tests.UI/Docs/Tools.md
@@ -5,7 +5,6 @@
 - Chrome needs to be installed on your machine, the latest version. If you also want to test other browsers then install the latest version of each of them:
   - For Edge only the new Chromium-based Edge is supported that you can download from [here](https://www.microsoft.com/en-us/edge).
   - For Firefox it needs to be installed too.
-  - For IE you'll need to do [some manual configuration](https://github.com/SeleniumHQ/selenium/wiki/InternetExplorerDriver#required-configuration) in the browser.
 - Browser driver setup is automated with [Atata.WebDriverSetup](https://github.com/atata-framework/atata-webdriversetup).
 - There are multiple recording tools available for Selenium but the "official" one which works pretty well is [Selenium IDE](https://www.selenium.dev/selenium-ide/) (which is a Chrome/Firefox extension). To fine-tune XPath queries and CSS selectors and also to record tests check out [ChroPath](https://chrome.google.com/webstore/detail/chropath/ljngjbnaijcbncmcnjfhigebomdlkcjo/) (the [Xpath cheat sheet](https://devhints.io/xpath) is a great resource too, and [XmlToolBox](https://xmltoolbox.appspot.com/xpath_generator.html) can help you with quick XPath queries).
 - Accessibility checking can be done with [axe](https://github.com/dequelabs/axe-core) via [Selenium.Axe for .NET](https://github.com/TroyWalshProf/SeleniumAxeDotnet).

--- a/Lombiq.Tests.UI/KillLeftoverProcesses.bat
+++ b/Lombiq.Tests.UI/KillLeftoverProcesses.bat
@@ -1,6 +1,5 @@
 taskkill /f /im "dotnet.exe"
 taskkill /f /im "chromedriver.exe"
 taskkill /f /im "geckodriver.exe"
-taskkill /f /im "IEDriverServer.exe"
 taskkill /f /im "msedgedriver.exe"
 taskkill /f /im "Lombiq.UITestingToolbox.AppUnderTest*"

--- a/Lombiq.Tests.UI/Lombiq.Tests.UI.csproj
+++ b/Lombiq.Tests.UI/Lombiq.Tests.UI.csproj
@@ -8,7 +8,6 @@
     projects would need to add the packages too. -->
     <PublishChromeDriver>true</PublishChromeDriver>
     <PublishGeckoDriver>true</PublishGeckoDriver>
-    <PublishIEDriver>true</PublishIEDriver>
     <PublishMsEdgeDriver>true</PublishMsEdgeDriver>
     <IsPackable>true</IsPackable>
   </PropertyGroup>

--- a/Lombiq.Tests.UI/Services/AtataFactory.cs
+++ b/Lombiq.Tests.UI/Services/AtataFactory.cs
@@ -92,7 +92,6 @@ public static class AtataFactory
                     Browser.Chrome => await WebDriverFactory.CreateChromeDriverAsync(browserConfiguration, pageLoadTimeout),
                     Browser.Edge => await WebDriverFactory.CreateEdgeDriverAsync(browserConfiguration, pageLoadTimeout),
                     Browser.Firefox => await WebDriverFactory.CreateFirefoxDriverAsync(browserConfiguration, pageLoadTimeout),
-                    Browser.InternetExplorer => await WebDriverFactory.CreateInternetExplorerDriverAsync(browserConfiguration, pageLoadTimeout),
                     _ => throw new InvalidOperationException($"Unknown browser: {browserConfiguration.Browser}."),
                 };
             }

--- a/Lombiq.Tests.UI/Services/OrchardCoreUITestExecutorConfiguration.cs
+++ b/Lombiq.Tests.UI/Services/OrchardCoreUITestExecutorConfiguration.cs
@@ -24,7 +24,8 @@ public enum Browser
     /// No browser will be used. Useful for testing things that don't require a browser, like API endpoints or running
     /// security scans.
     /// </summary>
-    None,
+    /// Due to removal of one browser, None needs to keep value of 4.
+    None = 4,
 }
 
 public class OrchardCoreUITestExecutorConfiguration

--- a/Lombiq.Tests.UI/Services/OrchardCoreUITestExecutorConfiguration.cs
+++ b/Lombiq.Tests.UI/Services/OrchardCoreUITestExecutorConfiguration.cs
@@ -19,7 +19,6 @@ public enum Browser
     Chrome,
     Edge,
     Firefox,
-    InternetExplorer,
 
     /// <summary>
     /// No browser will be used. Useful for testing things that don't require a browser, like API endpoints or running

--- a/Lombiq.Tests.UI/Services/OrchardCoreUITestExecutorConfiguration.cs
+++ b/Lombiq.Tests.UI/Services/OrchardCoreUITestExecutorConfiguration.cs
@@ -24,8 +24,7 @@ public enum Browser
     /// No browser will be used. Useful for testing things that don't require a browser, like API endpoints or running
     /// security scans.
     /// </summary>
-    /// Due to removal of one browser, None needs to keep value of 4.
-    None = 4,
+    None,
 }
 
 public class OrchardCoreUITestExecutorConfiguration

--- a/Lombiq.Tests.UI/Services/WebDriverFactory.cs
+++ b/Lombiq.Tests.UI/Services/WebDriverFactory.cs
@@ -6,7 +6,6 @@ using OpenQA.Selenium.Chrome;
 using OpenQA.Selenium.Chromium;
 using OpenQA.Selenium.Edge;
 using OpenQA.Selenium.Firefox;
-using OpenQA.Selenium.IE;
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/Lombiq.Tests.UI/Services/WebDriverFactory.cs
+++ b/Lombiq.Tests.UI/Services/WebDriverFactory.cs
@@ -129,19 +129,6 @@ public static class WebDriverFactory
                 return new FirefoxDriver(options).SetCommonTimeouts(pageLoadTimeout);
             }));
 
-    public static Task<Func<InternetExplorerDriver>> CreateInternetExplorerDriverAsync(
-        BrowserConfiguration configuration, TimeSpan pageLoadTimeout) =>
-        CreateDriverAsync(BrowserNames.InternetExplorer, () => Task.FromResult(() =>
-        {
-            var options = new InternetExplorerOptions().SetCommonOptions();
-
-            // IE doesn't support this.
-            options.AcceptInsecureCertificates = false;
-            configuration.BrowserOptionsConfigurator?.Invoke(options);
-
-            return new InternetExplorerDriver(options).SetCommonTimeouts(pageLoadTimeout);
-        }));
-
     private static TDriverOptions SetCommonOptions<TDriverOptions>(this TDriverOptions driverOptions)
         where TDriverOptions : DriverOptions
     {


### PR DESCRIPTION
[OSOE-663](https://lombiq.atlassian.net/browse/OSOE-663)
Fixes #299

[OSOE-663]: https://lombiq.atlassian.net/browse/OSOE-663?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ