### PR TITLE
OSOE-969: Add Downloads folder in temp and test dump directories

### DIFF
--- a/Lombiq.Tests.UI/Constants/DirectoryPaths.cs
+++ b/Lombiq.Tests.UI/Constants/DirectoryPaths.cs
@@ -9,6 +9,7 @@ public static class DirectoryPaths
     public const string SetupSnapshot = nameof(SetupSnapshot);
     public const string Temp = nameof(Temp);
     public const string Screenshots = nameof(Screenshots);
+    public const string Downloads = nameof(Downloads);
 
     public static string GetTempDirectoryPath(params string[] subDirectoryNames) =>
         Path.Combine([Environment.CurrentDirectory, Temp, .. subDirectoryNames]);

--- a/Lombiq.Tests.UI/Services/BrowserConfiguration.cs
+++ b/Lombiq.Tests.UI/Services/BrowserConfiguration.cs
@@ -49,4 +49,10 @@ public class BrowserConfiguration
     /// Gets a list of command line arguments that were passed to the driver during the driver instance creation.
     /// </summary>
     public IList<string> Arguments { get; } = [];
+
+    /// <summary>
+    /// Gets or sets the context ID, to be used during driver creation when the <see cref="UITestContext"/> does not
+    /// exist yet.
+    /// </summary>
+    internal string ContextId { get; set; }
 }

--- a/Lombiq.Tests.UI/Services/BrowserConfiguration.cs
+++ b/Lombiq.Tests.UI/Services/BrowserConfiguration.cs
@@ -54,5 +54,5 @@ public class BrowserConfiguration
     /// Gets or sets the context ID, to be used during driver creation when the <see cref="UITestContext"/> does not
     /// exist yet.
     /// </summary>
-    internal string ContextId { get; set; }
+    internal string UITestContextId { get; set; }
 }

--- a/Lombiq.Tests.UI/Services/UITestContext.cs
+++ b/Lombiq.Tests.UI/Services/UITestContext.cs
@@ -318,6 +318,13 @@ public class UITestContext
     public string GetTempSubDirectoryPath(params string[] subDirectoryNames) =>
         DirectoryPaths.GetTempDirectoryPath([Id, .. subDirectoryNames]);
 
+    /// <summary>
+    /// Returns a path in the <see cref="DirectoryPaths.Downloads"/> subdirectory inside the current test instance's
+    /// <see cref="DirectoryPaths.Temp"/> directory.
+    /// </summary>
+    public string GetDownloadFilePath(params string[] subDirectoryNames) =>
+        DirectoryPaths.GetTempDirectoryPath([Id, DirectoryPaths.Downloads, .. subDirectoryNames]);
+
     private bool IsAlert()
     {
         // If there's an alert (which can happen mostly after a click but also after navigating) then all other driver

--- a/Lombiq.Tests.UI/Services/UITestContext.cs
+++ b/Lombiq.Tests.UI/Services/UITestContext.cs
@@ -147,6 +147,12 @@ public class UITestContext
     /// </summary>
     public string ScreenshotsDirectoryPath => GetTempSubDirectoryPath(DirectoryPaths.Screenshots);
 
+    /// <summary>
+    /// Gets the absolute path of the <see cref="DirectoryPaths.Downloads"/> subdirectory inside the current test
+    /// instance's <see cref="DirectoryPaths.Temp"/> directory.
+    /// </summary>
+    public string DownloadsDirectoryPath => GetTempSubDirectoryPath(DirectoryPaths.Downloads);
+
     // This is a central context object, we need the data to be passed in the constructor.
 #pragma warning disable S107 // Methods should not have too many parameters
     public UITestContext(

--- a/Lombiq.Tests.UI/Services/UITestExecutionSession.cs
+++ b/Lombiq.Tests.UI/Services/UITestExecutionSession.cs
@@ -590,7 +590,7 @@ internal sealed class UITestExecutionSession : IAsyncDisposable
     private async Task<UITestContext> CreateContextAsync(Uri testStartRelativeUri)
     {
         var contextId = Guid.NewGuid().ToString();
-        _configuration.BrowserConfiguration.ContextId = contextId;
+        _configuration.BrowserConfiguration.UITestContextId = contextId;
 
         FileSystemHelper.EnsureDirectoryExists(DirectoryPaths.GetTempDirectoryPath(contextId));
 

--- a/Lombiq.Tests.UI/Services/UITestExecutionSession.cs
+++ b/Lombiq.Tests.UI/Services/UITestExecutionSession.cs
@@ -590,6 +590,7 @@ internal sealed class UITestExecutionSession : IAsyncDisposable
     private async Task<UITestContext> CreateContextAsync(Uri testStartRelativeUri)
     {
         var contextId = Guid.NewGuid().ToString();
+        _configuration.BrowserConfiguration.ContextId = contextId;
 
         FileSystemHelper.EnsureDirectoryExists(DirectoryPaths.GetTempDirectoryPath(contextId));
 
@@ -789,6 +790,13 @@ internal sealed class UITestExecutionSession : IAsyncDisposable
         if (_dumpConfiguration.CaptureScreenshots)
         {
             await CreateScreenshotsDumpAsync(debugInformationPath);
+        }
+
+        if (_dumpConfiguration.CaptureDownloads && Directory.Exists(_context.DownloadsDirectoryPath))
+        {
+            FileSystem.CopyDirectory(
+                _context.DownloadsDirectoryPath,
+                Path.Combine(debugInformationPath, DirectoryPaths.Downloads));
         }
 
         if (_dumpConfiguration.CaptureHtmlSource)

--- a/Lombiq.Tests.UI/Services/UITestExecutorTestDumpConfiguration.cs
+++ b/Lombiq.Tests.UI/Services/UITestExecutorTestDumpConfiguration.cs
@@ -16,6 +16,7 @@ public class UITestExecutorTestDumpConfiguration
     public bool CreateTestDump { get; set; } = true;
     public bool CaptureAppSnapshot { get; set; } = true;
     public bool CaptureScreenshots { get; set; } = true;
+    public bool CaptureDownloads { get; set; } = true;
     public bool CaptureHtmlSource { get; set; } = true;
     public bool CaptureBrowserLog { get; set; } = true;
 }

--- a/Lombiq.Tests.UI/Services/WebDriverFactory.cs
+++ b/Lombiq.Tests.UI/Services/WebDriverFactory.cs
@@ -245,7 +245,7 @@ public static class WebDriverFactory
 
     private static string PrepareDownloadDirectory(BrowserConfiguration configuration)
     {
-        var downloadPath = DirectoryPaths.GetTempDirectoryPath(configuration.ContextId, DirectoryPaths.Downloads);
+        var downloadPath = DirectoryPaths.GetTempDirectoryPath(configuration.UITestContextId, DirectoryPaths.Downloads);
         FileSystemHelper.EnsureDirectoryExists(downloadPath);
         return downloadPath;
     }

--- a/Lombiq.Tests.UI/Services/WebDriverFactory.cs
+++ b/Lombiq.Tests.UI/Services/WebDriverFactory.cs
@@ -1,5 +1,7 @@
 using Atata.WebDriverSetup;
 using Lombiq.HelpfulLibraries.Cli.Helpers;
+using Lombiq.HelpfulLibraries.Common.Utilities;
+using Lombiq.Tests.UI.Constants;
 using Lombiq.Tests.UI.Extensions;
 using OpenQA.Selenium;
 using OpenQA.Selenium.Chrome;
@@ -113,6 +115,13 @@ public static class WebDriverFactory
                 options.SetPreference("browser.preferences.defaultPerformanceSettings.enabled", preferenceValue: false);
                 options.SetPreference("layers.acceleration.disabled", preferenceValue: true);
 
+                // Set the download path to inside the context-specific temp directory to avoid clashes from parallel
+                // tests, and to make it available for test dumps.
+                options.SetPreference("browser.download.folderList", 2);
+                options.SetPreference("browser.download.dir", PrepareDownloadDirectory(configuration));
+                options.SetPreference("browser.download.useDownloadDir", preferenceValue: true);
+                options.SetPreference("pdfjs.disabled", preferenceValue: true);
+
                 if (configuration.Headless) options.AddArgument("--headless");
 
                 configuration.BrowserOptionsConfigurator?.Invoke(options);
@@ -183,6 +192,10 @@ public static class WebDriverFactory
 
         if (configuration.Headless) options.AddArgument("headless");
 
+        // Set the download path to inside the context-specific temp directory to avoid clashes from parallel tests, and
+        // to make it available for test dumps.
+        options.AddUserProfilePreference("download.default_directory", PrepareDownloadDirectory(configuration));
+
         return options;
     }
 
@@ -228,6 +241,13 @@ public static class WebDriverFactory
     private static void AutoSetup(string browserName)
     {
         lock (_setupLock) DriverSetup.AutoSetUp(browserName);
+    }
+
+    private static string PrepareDownloadDirectory(BrowserConfiguration configuration)
+    {
+        var downloadPath = DirectoryPaths.GetTempDirectoryPath(configuration.ContextId, DirectoryPaths.Downloads);
+        FileSystemHelper.EnsureDirectoryExists(downloadPath);
+        return downloadPath;
     }
 
     private sealed class ChromeConfiguration


### PR DESCRIPTION
[OSOE-969](https://lombiq.atlassian.net/browse/OSOE-969)
... and configure browsers to use it.

[OSOE-969]: https://lombiq.atlassian.net/browse/OSOE-969?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ