### PR TITLE
LMBQ-502: Turning off rule 10062 in security scanning because of a lot of false positives

### DIFF
--- a/Lombiq.Tests.UI/SecurityScanning/AutomationFrameworkPlans/FullScan.yml
+++ b/Lombiq.Tests.UI/SecurityScanning/AutomationFrameworkPlans/FullScan.yml
@@ -65,7 +65,7 @@ jobs:
       # This rule generates false positives on UUIDs or random numeric sequences, see https://github.com/zaproxy/zaproxy/issues/8303.
       - id: 10062
         name: The response contains Personally Identifiable Information, such as CC number, SSN and similar sensitive data.
-        threshold: off
+        threshold: 'off'
     name: passiveScan-config
     type: passiveScan-config
   - alertFilters:

--- a/Lombiq.Tests.UI/SecurityScanning/AutomationFrameworkPlans/FullScan.yml
+++ b/Lombiq.Tests.UI/SecurityScanning/AutomationFrameworkPlans/FullScan.yml
@@ -65,7 +65,7 @@ jobs:
       # This rule generates false positives on UUIDs or random numeric sequences, see https://github.com/zaproxy/zaproxy/issues/8303.
       - id: 10062
         name: The response contains Personally Identifiable Information, such as CC number, SSN and similar sensitive data.
-        threshold: high
+        threshold: off
     name: passiveScan-config
     type: passiveScan-config
   - alertFilters:


### PR DESCRIPTION
LMBQ-502