### PR TITLE
OSOE-1131: Downgrading Atata to 3.5.0 and disabling Renovate updates

### DIFF
--- a/Lombiq.Tests.UI/Lombiq.Tests.UI.csproj
+++ b/Lombiq.Tests.UI/Lombiq.Tests.UI.csproj
@@ -64,7 +64,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Atata" Version="3.6.0" />
+    <PackageReference Include="Atata" Version="3.5.0" />
     <PackageReference Include="Atata.Bootstrap" Version="3.0.0" />
     <PackageReference Include="Atata.HtmlValidation" Version="3.2.0" />
     <PackageReference Include="Atata.WebDriverExtras" Version="3.2.0" />

--- a/renovate.json5
+++ b/renovate.json5
@@ -9,6 +9,8 @@
             matchPackageNames: [
                 'Atata*',
             ],
+            // Disabled and staying on 3.5.0 until this is fixed: https://github.com/atata-framework/atata/issues/857.
+            enabled: false,
         },
         {
             groupName: 'Deque.AxeCore',


### PR DESCRIPTION
[OSOE-1131](https://lombiq.atlassian.net/browse/OSOE-1131)
Due to https://github.com/atata-framework/atata/issues/857.

[OSOE-1131]: https://lombiq.atlassian.net/browse/OSOE-1131?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ