### PR TITLE
NEST-632: Throw helpful exception when trying to enable a feature that doesn't exist

### DIFF
--- a/Lombiq.Tests.UI/Extensions/ShortcutsUITestContextExtensions.cs
+++ b/Lombiq.Tests.UI/Extensions/ShortcutsUITestContextExtensions.cs
@@ -259,7 +259,9 @@ public static class ShortcutsUITestContextExtensions
                 var shellFeatureManager = serviceProvider.GetRequiredService<IShellFeaturesManager>();
                 var extensionManager = serviceProvider.GetRequiredService<IExtensionManager>();
 
-                var feature = extensionManager.GetFeature(featureId);
+                var feature = extensionManager.GetFeature(featureId)
+                    ?? throw new InvalidOperationException(
+                        $"No feature found with the ID {featureId}. Check if its extension is added to the web project.");
 
                 return shellFeatureManager.EnableFeaturesAsync([feature], force: true);
             },


### PR DESCRIPTION
[NEST-632](https://lombiq.atlassian.net/browse/NEST-632)

[NEST-632]: https://lombiq.atlassian.net/browse/NEST-632?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ