### PR TITLE
OSOE-1192: Update dependency Swashbuckle.AspNetCore to v10

### DIFF
--- a/Lombiq.Tests.UI.Shortcuts/Lombiq.Tests.UI.Shortcuts.csproj
+++ b/Lombiq.Tests.UI.Shortcuts/Lombiq.Tests.UI.Shortcuts.csproj
@@ -43,7 +43,7 @@
     <PackageReference Include="OrchardCore.ResourceManagement.Abstractions" Version="2.1.0" />
     <PackageReference Include="OrchardCore.Workflows" Version="2.1.0" />
     <PackageReference Include="OrchardCore.Search.Elasticsearch.Core" Version="2.1.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.6" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.0.1" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(NuGetBuild)' != 'true'">

--- a/Lombiq.Tests.UI.Shortcuts/Startup.cs
+++ b/Lombiq.Tests.UI.Shortcuts/Startup.cs
@@ -4,7 +4,7 @@ using Lombiq.Tests.UI.Shortcuts.Services;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi;
 using OrchardCore.Data.YesSql;
 using OrchardCore.Modules;
 using System;


### PR DESCRIPTION
[OSOE-1192](https://lombiq.atlassian.net/browse/OSOE-1192)

[OSOE-1192]: https://lombiq.atlassian.net/browse/OSOE-1192?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ