### PR TITLE
OSOE-1213: Disable ZAP alert 10116 \"ZAP is Out of Date\" since it's not useful in automated scans

### DIFF
--- a/Lombiq.Tests.UI/SecurityScanning/AutomationFrameworkPlans/Baseline.yml
+++ b/Lombiq.Tests.UI/SecurityScanning/AutomationFrameworkPlans/Baseline.yml
@@ -67,7 +67,7 @@ jobs:
       # automated scans, and it can also break assertions.
       - name: ZAP is Out of Date
         id: 10116
-        threshold: "off"
+        threshold: 'off'
     name: passiveScan-config
     type: passiveScan-config
   - alertFilters:

--- a/Lombiq.Tests.UI/SecurityScanning/AutomationFrameworkPlans/Baseline.yml
+++ b/Lombiq.Tests.UI/SecurityScanning/AutomationFrameworkPlans/Baseline.yml
@@ -63,6 +63,11 @@ jobs:
       - id: 10062
         name: The response contains Personally Identifiable Information, such as CC number, SSN and similar sensitive data.
         threshold: high
+      # Adds an alert to the scan if a newer ZAP version is available, as soon as it's released. This isn't useful in
+      # automated scans, and it can also break assertions.
+      - name: ZAP is Out of Date
+        id: 10116
+        threshold: "off"
     name: passiveScan-config
     type: passiveScan-config
   - alertFilters:

--- a/Lombiq.Tests.UI/SecurityScanning/AutomationFrameworkPlans/FullScan.yml
+++ b/Lombiq.Tests.UI/SecurityScanning/AutomationFrameworkPlans/FullScan.yml
@@ -66,6 +66,11 @@ jobs:
       - id: 10062
         name: The response contains Personally Identifiable Information, such as CC number, SSN and similar sensitive data.
         threshold: 'off'
+      # Adds an alert to the scan if a newer ZAP version is available, as soon as it's released. This isn't useful in
+      # automated scans, and it can also break assertions.
+      - name: ZAP is Out of Date
+        id: 10116
+        threshold: "off"
     name: passiveScan-config
     type: passiveScan-config
   - alertFilters:

--- a/Lombiq.Tests.UI/SecurityScanning/AutomationFrameworkPlans/FullScan.yml
+++ b/Lombiq.Tests.UI/SecurityScanning/AutomationFrameworkPlans/FullScan.yml
@@ -70,7 +70,7 @@ jobs:
       # automated scans, and it can also break assertions.
       - name: ZAP is Out of Date
         id: 10116
-        threshold: "off"
+        threshold: 'off'
     name: passiveScan-config
     type: passiveScan-config
   - alertFilters:

--- a/Lombiq.Tests.UI/SecurityScanning/AutomationFrameworkPlans/GraphQL.yml
+++ b/Lombiq.Tests.UI/SecurityScanning/AutomationFrameworkPlans/GraphQL.yml
@@ -64,7 +64,7 @@ jobs:
       # automated scans, and it can also break assertions.
       - name: ZAP is Out of Date
         id: 10116
-        threshold: "off"
+        threshold: 'off'
     name: passiveScan-config
     type: passiveScan-config
   - parameters:

--- a/Lombiq.Tests.UI/SecurityScanning/AutomationFrameworkPlans/GraphQL.yml
+++ b/Lombiq.Tests.UI/SecurityScanning/AutomationFrameworkPlans/GraphQL.yml
@@ -60,6 +60,11 @@ jobs:
       - id: 10062
         name: The response contains Personally Identifiable Information, such as CC number, SSN and similar sensitive data.
         threshold: high
+      # Adds an alert to the scan if a newer ZAP version is available, as soon as it's released. This isn't useful in
+      # automated scans, and it can also break assertions.
+      - name: ZAP is Out of Date
+        id: 10116
+        threshold: "off"
     name: passiveScan-config
     type: passiveScan-config
   - parameters:

--- a/Lombiq.Tests.UI/SecurityScanning/AutomationFrameworkPlans/OpenAPI.yml
+++ b/Lombiq.Tests.UI/SecurityScanning/AutomationFrameworkPlans/OpenAPI.yml
@@ -60,6 +60,11 @@ jobs:
       - id: 10062
         name: The response contains Personally Identifiable Information, such as CC number, SSN and similar sensitive data.
         threshold: high
+      # Adds an alert to the scan if a newer ZAP version is available, as soon as it's released. This isn't useful in
+      # automated scans, and it can also break assertions.
+      - name: ZAP is Out of Date
+        id: 10116
+        threshold: "off"
     name: passiveScan-config
     type: passiveScan-config
   - alertFilters:

--- a/Lombiq.Tests.UI/SecurityScanning/AutomationFrameworkPlans/OpenAPI.yml
+++ b/Lombiq.Tests.UI/SecurityScanning/AutomationFrameworkPlans/OpenAPI.yml
@@ -64,7 +64,7 @@ jobs:
       # automated scans, and it can also break assertions.
       - name: ZAP is Out of Date
         id: 10116
-        threshold: "off"
+        threshold: 'off'
     name: passiveScan-config
     type: passiveScan-config
   - alertFilters:


### PR DESCRIPTION
[OSOE-1213](https://lombiq.atlassian.net/browse/OSOE-1213)

[OSOE-1213]: https://lombiq.atlassian.net/browse/OSOE-1213?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ