### PR TITLE
NEST-649: DRY Google Fonts subresource integrity check and reCAPTCH-related false positives disable during security scans

### DIFF
--- a/Lombiq.Tests.UI.Samples/Tests/SecurityScanningTests.cs
+++ b/Lombiq.Tests.UI.Samples/Tests/SecurityScanningTests.cs
@@ -69,7 +69,7 @@ public class SecurityScanningTests : UITestBase
     // - Adds a false positive rule filter for the Absence of Anti-CSRF Tokens rule, but only for the search form with
     //   the ID or class "my-search-form" which is displayed on every page. For less common filters (e.g., filters other
     //   than by URL), you can use the .ModifyZapPlan() and .AddFalsePositiveRuleFilter() extension methods to configure
-    //   the action filter YAML node directly.
+    //   the action filter YAML node directly, as the AddFalsePositiveRuleFilterForEvidence() method does.
     // - Configures sign in with a user account. This is what the scan will start with. This doesn't matter much with
     //   the Blog recipe, because nothing on the frontend will change. You can use this to scan authenticated features
     //   too. This is necessary because ZAP uses its own spider so it doesn't share session or cookies with the browser.
@@ -89,17 +89,11 @@ public class SecurityScanningTests : UITestBase
                     .DisablePassiveScanRule(10020, "The response does not include either Content-Security-Policy with 'frame-ancestors' directive.")
                     .DisableSubresourceIntegrityAttributeMissingRuleForGoogleFonts()
                     .DisableScanRuleForUrlWithRegex(".*/about", 10038, "Content Security Policy (CSP) Header Not Set")
-                    .ModifyZapPlan(plan => plan
-                        .AddFalsePositiveRuleFilter(
-                            ".*",
-                            10202,
-                            "Absence of Anti-CSRF Tokens",
-                            "The search form doesn't alter the state of the application so anti-CSRF tokens are not needed.",
-                            node =>
-                            {
-                                node.Children["evidence"] = ".*my-search-form.*";
-                                node.Children["evidenceRegex"] = "true";
-                            }))
+                    .AddFalsePositiveRuleFilterForEvidence(
+                        10202,
+                        "Absence of Anti-CSRF Tokens",
+                        "The search form doesn't alter the state of the application so anti-CSRF tokens are not needed.",
+                        ".*my-search-form.*")
                     .SignIn(),
                 sarifLog => sarifLog.Runs[0].Results.Count.ShouldBe(0)),
             changeConfiguration: configuration => configuration.UseAssertAppLogsForSecurityScan());
@@ -181,18 +175,6 @@ public class SecurityScanningTests : UITestBase
 
                 await changeConfigurationAsync(configuration);
             });
-}
-
-internal static class SecurityScanConfigurationExtensions
-{
-    // Google Fonts resources lack subresource integrity attributes. This can't be fixed, see:
-    // https://github.com/google/fonts/issues/473.
-    public static SecurityScanConfiguration DisableSubresourceIntegrityAttributeMissingRuleForGoogleFonts(
-        this SecurityScanConfiguration configuration) =>
-        configuration.DisablePassiveScanRule(
-            90003,
-            "Sub Resource Integrity Attribute Missing for " +
-            "<link href='https://fonts.googleapis.com/css?family=Lora:400,700,400italic,700italic' rel='stylesheet' type='text/css'>");
 }
 
 // END OF TRAINING SECTION: Security scanning.

--- a/Lombiq.Tests.UI/SecurityScanning/OrchardCoreUITestExecutorConfigurationExtensions.cs
+++ b/Lombiq.Tests.UI/SecurityScanning/OrchardCoreUITestExecutorConfigurationExtensions.cs
@@ -50,6 +50,7 @@ public static class OrchardCoreUITestExecutorConfigurationExtensions
             "System.IO.IOException: Not a directory",
             "System.IO.IOException: The filename, directory name, or volume label syntax is incorrect",
             "System.IO.DirectoryNotFoundException: Could not find a part of the path",
+            "System.IO.IOException: The directory name is invalid.",
             // This happens when a request's model contains a dictionary and a key is missing. While this can be a
             // legitimate application error, during a security scan it's more likely the result of an incomplete
             // artificially constructed request. So the means the ASP.NET Core model binding is working as intended.

--- a/Lombiq.Tests.UI/SecurityScanning/SecurityScanConfiguration.cs
+++ b/Lombiq.Tests.UI/SecurityScanning/SecurityScanConfiguration.cs
@@ -258,6 +258,58 @@ public class SecurityScanConfiguration
     }
 
     /// <summary>
+    /// Disables the subresource integrity attribute missing alert for Google Fonts resources, since these can't have
+    /// such attributes (see <see href="https://github.com/google/fonts/issues/473"/>).
+    /// </summary>
+    public SecurityScanConfiguration DisableSubresourceIntegrityAttributeMissingRuleForGoogleFonts() =>
+        AddFalsePositiveRuleFilterForEvidence(
+            90003,
+            "Sub Resource Integrity Attribute Missing",
+            "Google Fonts resources lack subresource integrity attributes. This can't be fixed, see: " +
+                "https://github.com/google/fonts/issues/473.",
+            ".*fonts.googleapis.com.*");
+
+    /// <summary>
+    /// Adds an <see href="https://www.zaproxy.org/docs/desktop/addons/alert-filters/">Alert Filter</see> to the ZAP
+    /// Automation Framework plan.
+    /// </summary>
+    /// <param name="ruleId">The ID of the rule. In the scan report, this is usually displayed as "Plugin Id".</param>
+    /// <param name="ruleName">
+    /// The human-readable name of the rule. Not required to turn off the rule, and its value doesn't matter. It's just
+    /// useful for the readability of the method call.
+    /// </param>
+    /// <param name="justification">
+    /// An informational text explaining why the alert in question is false positive. This helps the development of ZAP
+    /// by collecting which rules have the highest false positive rate (see <see
+    /// href="https://www.zaproxy.org/faq/how-do-i-handle-a-false-positive/"/>).
+    /// </param>
+    /// <param name="evidenceRegexPattern">
+    /// A regular expression pattern to match against the evidence field of the rule (this is available in the scan
+    /// results). You can use this to precisely target a given false positive.
+    /// </param>
+    /// <param name="urlRegexPattern">
+    /// A regular expression pattern to match URLs against. This should be a regex pattern that matches the whole
+    /// absolute URL, so something like ".*blog.*" to match /blog, /blog/my-post, etc.
+    /// </param>
+    public SecurityScanConfiguration AddFalsePositiveRuleFilterForEvidence(
+        int ruleId,
+        string ruleName,
+        string justification,
+        string evidenceRegexPattern,
+        string urlRegexPattern = ".*") =>
+        ModifyZapPlan(plan => plan
+            .AddFalsePositiveRuleFilter(
+                urlRegexPattern,
+                ruleId,
+                ruleName,
+                justification,
+                node =>
+                {
+                    node.Children["evidence"] = evidenceRegexPattern;
+                    node.Children["evidenceRegex"] = "true";
+                }));
+
+    /// <summary>
     /// Modifies the <see href="https://www.zaproxy.org/docs/automate/automation-framework/">Automation Framework</see>
     /// plan of <see href="https://www.zaproxy.org/">Zed Attack Proxy (ZAP)</see>, the tool used for the security scan.
     /// You can use this to do any arbitrary ZAP configuration.

--- a/Lombiq.Tests.UI/SecurityScanning/SecurityScanConfiguration.cs
+++ b/Lombiq.Tests.UI/SecurityScanning/SecurityScanConfiguration.cs
@@ -270,6 +270,26 @@ public class SecurityScanConfiguration
             ".*fonts.googleapis.com.*");
 
     /// <summary>
+    /// Disables reCAPTCHA-related false positives. Use this if the app uses reCAPTCHA.
+    /// </summary>
+    public SecurityScanConfiguration DisableFalsePositivesForReCaptcha()
+    {
+        var reCaptchaEvidenceRegex = ".*www.google.com:443/recaptcha/api.js.*";
+
+        return
+            AddFalsePositiveRuleFilterForEvidence(
+                90003,
+                "Sub Resource Integrity Attribute Missing",
+                "ReCAPTCHA resources may be updated any time, and thus can't have subresource integrity attributes.",
+                reCaptchaEvidenceRegex)
+            .AddFalsePositiveRuleFilterForEvidence(
+                10017,
+                "Cross-Domain JavaScript Source File Inclusion",
+                "ReCAPTCHA needs cross-domain source inclusion.",
+                reCaptchaEvidenceRegex);
+    }
+
+    /// <summary>
     /// Adds an <see href="https://www.zaproxy.org/docs/desktop/addons/alert-filters/">Alert Filter</see> to the ZAP
     /// Automation Framework plan.
     /// </summary>

--- a/Lombiq.Tests.UI/SecurityScanning/YamlDocumentExtensions.cs
+++ b/Lombiq.Tests.UI/SecurityScanning/YamlDocumentExtensions.cs
@@ -235,7 +235,7 @@ public static class YamlDocumentExtensions
     /// Automation Framework plan.
     /// </summary>
     /// <param name="ruleId">The ID of the rule. In the scan report, this is usually displayed as "Plugin Id".</param>
-    /// <param name="urlMatchingRegexPattern">
+    /// <param name="urlRegexPattern">
     /// A regular expression pattern to match URLs against. This should be a regex pattern that matches the whole
     /// absolute URL, so something like ".*blog.*" to match /blog, /blog/my-post, etc.
     /// </param>
@@ -243,9 +243,12 @@ public static class YamlDocumentExtensions
     /// The human-readable name of the rule. Not required to turn off the rule, and its value doesn't matter. It's just
     /// useful for the readability of the method call.
     /// </param>
+    /// <param name="configureFilter">
+    /// An optional action to further configure the alert filter node before it's added to the plan.
+    /// </param>
     public static YamlDocument AddDisableRuleFilter(
         this YamlDocument yamlDocument,
-        string urlMatchingRegexPattern,
+        string urlRegexPattern,
         int ruleId,
         string ruleName,
         Action<YamlMappingNode> configureFilter = null)
@@ -254,7 +257,7 @@ public static class YamlDocumentExtensions
         {
             { "ruleId", ruleId.ToTechnicalString() },
             { "ruleName", ruleName },
-            { "url", urlMatchingRegexPattern },
+            { "url", urlRegexPattern },
             { "urlRegex", "true" },
             { "newRisk", "Info" },
         };
@@ -272,13 +275,13 @@ public static class YamlDocumentExtensions
     /// </param>
     public static YamlDocument AddFalsePositiveRuleFilter(
         this YamlDocument yamlDocument,
-        string urlMatchingRegexPattern,
+        string urlRegexPattern,
         int ruleId,
         string ruleName,
         string justification,
         Action<YamlMappingNode> configureFilter = null) =>
         yamlDocument.AddDisableRuleFilter(
-            urlMatchingRegexPattern,
+            urlRegexPattern,
             ruleId,
             $"{ruleName}: {justification}",
             node =>


### PR DESCRIPTION
[NEST-649](https://lombiq.atlassian.net/browse/NEST-649)

[NEST-649]: https://lombiq.atlassian.net/browse/NEST-649?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ