### PR TITLE
OSOE-1229: Removing now unnecessary analyzer false positive suppression

### DIFF
--- a/Lombiq.Tests.UI/Services/GitHub/GitHubActionsGroupingTestOutputHelper.cs
+++ b/Lombiq.Tests.UI/Services/GitHub/GitHubActionsGroupingTestOutputHelper.cs
@@ -1,14 +1,9 @@
 using Lombiq.Tests.UI.Models;
 using System;
-using System.Diagnostics.CodeAnalysis;
 using Xunit;
 
 namespace Lombiq.Tests.UI.Services.GitHub;
 
-[SuppressMessage(
-    "Performance",
-    "MA0182:Avoid unused internal types",
-    Justification = "False positive: https://github.com/meziantou/Meziantou.Analyzer/issues/970.")]
 internal sealed class GitHubActionsGroupingTestOutputHelper : ITestOutputHelperDecorator
 {
     private readonly string _groupName;


### PR DESCRIPTION
[OSOE-1229](https://lombiq.atlassian.net/browse/OSOE-1229)

[OSOE-1229]: https://lombiq.atlassian.net/browse/OSOE-1229?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ