### PR TITLE
LMBQ-554: Adding the ability to set the environment (staging/prod) for remote tests more explicitly in configuration value, removing unused OrchardCore.Tenants dependency from Shortcuts

### DIFF
--- a/Lombiq.Tests.UI.Shortcuts/Lombiq.Tests.UI.Shortcuts.csproj
+++ b/Lombiq.Tests.UI.Shortcuts/Lombiq.Tests.UI.Shortcuts.csproj
@@ -30,7 +30,6 @@
 
   <ItemGroup>
     <PackageReference Include="OrchardCore.Module.Targets" Version="2.1.0" />
-    <PackageReference Include="OrchardCore.Tenants" Version="2.1.0" />
     <PackageReference Include="OrchardCore.Themes" Version="2.1.0" />
     <PackageReference Include="OrchardCore.Users" Version="2.1.0" />
     <PackageReference Include="OrchardCore.Media.Abstractions" Version="2.1.0" />

--- a/Lombiq.Tests.UI.Shortcuts/Manifest.cs
+++ b/Lombiq.Tests.UI.Shortcuts/Manifest.cs
@@ -19,7 +19,6 @@ using static Lombiq.Tests.UI.Shortcuts.ShortcutsFeatureIds;
         "OrchardCore.ContentTypes",
         "OrchardCore.DisplayManagement",
         "OrchardCore.Roles",
-        "OrchardCore.Tenants",
         "OrchardCore.Users",
     ]
 )]

--- a/Lombiq.Tests.UI/Helpers/RemoteTestHelper.cs
+++ b/Lombiq.Tests.UI/Helpers/RemoteTestHelper.cs
@@ -1,4 +1,5 @@
-﻿using System;
+using Lombiq.Tests.UI.Services;
+using System;
 
 namespace Lombiq.Tests.UI.Helpers;
 
@@ -6,5 +7,6 @@ public static class RemoteTestHelper
 {
     public static bool RunIsForProduction =>
         Environment.GetEnvironmentVariable("GITHUB_REPOSITORY")?.ContainsOrdinalIgnoreCase("swap") == true ||
-        Environment.GetEnvironmentVariable("GITHUB_EVENT_NAME")?.ContainsOrdinalIgnoreCase("schedule") == true;
+        Environment.GetEnvironmentVariable("GITHUB_EVENT_NAME")?.ContainsOrdinalIgnoreCase("schedule") == true ||
+        TestConfigurationManager.GetConfiguration("Environment", "staging").EndsWithOrdinalIgnoreCase("production");
 }


### PR DESCRIPTION
[LMBQ-554](https://lombiq.atlassian.net/browse/LMBQ-554)

[LMBQ-554]: https://lombiq.atlassian.net/browse/LMBQ-554?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ