### PR TITLE
OSOE-1240: Update Browsers to v145.0.7632.77, Non-Breaking Dependency Versions, Browsers to v145

### DIFF
--- a/Lombiq.Tests.UI.Shortcuts/Lombiq.Tests.UI.Shortcuts.csproj
+++ b/Lombiq.Tests.UI.Shortcuts/Lombiq.Tests.UI.Shortcuts.csproj
@@ -38,7 +38,7 @@
     <PackageReference Include="OrchardCore.ResourceManagement.Abstractions" Version="2.1.0" />
     <PackageReference Include="OrchardCore.Workflows" Version="2.1.0" />
     <PackageReference Include="OrchardCore.Search.Elasticsearch.Core" Version="2.1.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.2" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.4" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(NuGetBuild)' != 'true'">

--- a/Lombiq.Tests.UI/.config/dotnet-tools.json
+++ b/Lombiq.Tests.UI/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "rnwood.smtp4dev": {
-      "version": "3.12.0",
+      "version": "3.14.0",
       "commands": [
         "smtp4dev"
       ]

--- a/Lombiq.Tests.UI/Services/WebDriverFactory.cs
+++ b/Lombiq.Tests.UI/Services/WebDriverFactory.cs
@@ -37,7 +37,7 @@ public static class WebDriverFactory
             // is updated automatically by Renovate.
             // If anything on this line is changed, be sure to adjust the regex in the renovate.json5 config file in the
             // root too.
-            chromeConfig.Options.BrowserVersion = "145.0.7632.46";
+            chromeConfig.Options.BrowserVersion = "145.0.7632.77";
 
             configuration.BrowserOptionsConfigurator?.Invoke(chromeConfig.Options);
 

--- a/Lombiq.Tests.UI/Services/WebDriverFactory.cs
+++ b/Lombiq.Tests.UI/Services/WebDriverFactory.cs
@@ -68,17 +68,17 @@ public static class WebDriverFactory
             // root too.
             if (OperatingSystem.IsLinux())
             {
-                var linuxEdgeVersion = "144.0.3719.115";
+                var linuxEdgeVersion = "145.0.3800.58";
                 options.BrowserVersion = linuxEdgeVersion;
             }
             else if (OperatingSystem.IsWindows())
             {
-                var windowsEdgeVersion = "144.0.3719.115";
+                var windowsEdgeVersion = "145.0.3800.65";
                 options.BrowserVersion = windowsEdgeVersion;
             }
             else if (!OperatingSystem.IsMacOS())
             {
-                var macOsEdgeVersion = "144.0.3719.115";
+                var macOsEdgeVersion = "145.0.3800.58";
                 options.BrowserVersion = macOsEdgeVersion;
             }
 

--- a/Lombiq.Tests.UI/ui-testing-toolkit.mjs
+++ b/Lombiq.Tests.UI/ui-testing-toolkit.mjs
@@ -409,7 +409,7 @@ async function runTest(test, configureOptions = null) {
     // updated automatically by Renovate.
     // If anything on this line is changed, be sure to adjust the regex in the renovate.json5 config file in the root
     // too.
-    options.setBrowserVersion('145.0.7632.46');
+    options.setBrowserVersion('145.0.7632.77');
 
     console.log(`Using Chrome version ${options.getBrowserVersion()}.`);
 


### PR DESCRIPTION
[OSOE-1240](https://lombiq.atlassian.net/browse/OSOE-1240)

[OSOE-1240]: https://lombiq.atlassian.net/browse/OSOE-1240?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ