### PR TITLE
OSOE-1254: Update browsers: Chrome 147.0.7727.50, Edge 146.0.3856.97, fix MA0040 warning

### DIFF
--- a/Lombiq.Tests.UI/Extensions/NavigationUITestContextExtensions.cs
+++ b/Lombiq.Tests.UI/Extensions/NavigationUITestContextExtensions.cs
@@ -338,7 +338,8 @@ public static class NavigationUITestContextExtensions
             nameof(WaitForPageLoad),
             context.Driver.Url,
             () => new WebDriverWait(context.Driver, TimeSpan.FromSeconds(10)).Until(
-                driver => driver.ExecuteScript("return document.readyState").Equals("complete")));
+                driver => driver.ExecuteScript("return document.readyState").Equals("complete"),
+                context.Configuration.TestCancellationToken));
 
     public static Task SetTaxonomyFieldByIndexAsync(this UITestContext context, string taxonomyId, int index)
     {

--- a/Lombiq.Tests.UI/Services/WebDriverFactory.cs
+++ b/Lombiq.Tests.UI/Services/WebDriverFactory.cs
@@ -37,7 +37,7 @@ public static class WebDriverFactory
             // is updated automatically by Renovate.
             // If anything on this line is changed, be sure to adjust the regex in the renovate.json5 config file in the
             // root too.
-            chromeConfig.Options.BrowserVersion = "147.0.7727.24";
+            chromeConfig.Options.BrowserVersion = "147.0.7727.50";
 
             configuration.BrowserOptionsConfigurator?.Invoke(chromeConfig.Options);
 
@@ -68,17 +68,17 @@ public static class WebDriverFactory
             // root too.
             if (OperatingSystem.IsLinux())
             {
-                var linuxEdgeVersion = "146.0.3856.84";
+                var linuxEdgeVersion = "146.0.3856.97";
                 options.BrowserVersion = linuxEdgeVersion;
             }
             else if (OperatingSystem.IsWindows())
             {
-                var windowsEdgeVersion = "146.0.3856.84";
+                var windowsEdgeVersion = "146.0.3856.97";
                 options.BrowserVersion = windowsEdgeVersion;
             }
             else if (!OperatingSystem.IsMacOS())
             {
-                var macOsEdgeVersion = "146.0.3856.84";
+                var macOsEdgeVersion = "146.0.3856.97";
                 options.BrowserVersion = macOsEdgeVersion;
             }
 

--- a/Lombiq.Tests.UI/ui-testing-toolkit.mjs
+++ b/Lombiq.Tests.UI/ui-testing-toolkit.mjs
@@ -409,7 +409,7 @@ async function runTest(test, configureOptions = null) {
     // updated automatically by Renovate.
     // If anything on this line is changed, be sure to adjust the regex in the renovate.json5 config file in the root
     // too.
-    options.setBrowserVersion('147.0.7727.24');
+    options.setBrowserVersion('147.0.7727.50');
 
     console.log(`Using Chrome version ${options.getBrowserVersion()}.`);
 


### PR DESCRIPTION
[OSOE-1254](https://lombiq.atlassian.net/browse/OSOE-1254): Update browser versions and fix MA0040 analyzer warning.

- Chrome 147.0.7727.24 → 147.0.7727.50
- Edge 146.0.3856.84 → 146.0.3856.97
- Fix MA0040 in NavigationUITestContextExtensions: add CancellationToken to WebDriverWait.Until

[OSOE-1254]: https://lombiq.atlassian.net/browse/OSOE-1254?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ