### PR TITLE
NEST-644: Fixing that setting AccessibilityCheckingConfiguration.CreateReportAlways failed if the test had more than one page

### DIFF
--- a/Lombiq.Tests.UI/Constants/AccessibilityCheckingConstants.cs
+++ b/Lombiq.Tests.UI/Constants/AccessibilityCheckingConstants.cs
@@ -1,0 +1,7 @@
+namespace Lombiq.Tests.UI.Constants;
+
+internal static class AccessibilityCheckingConstants
+{
+    public const string AccessibilityReportFileNameWithoutExtension = "AccessibilityReport";
+    public const string AccessibilityReportFileName = AccessibilityReportFileNameWithoutExtension + ".html";
+}

--- a/Lombiq.Tests.UI/Extensions/AccessibilityCheckingUITestContextExtensions.cs
+++ b/Lombiq.Tests.UI/Extensions/AccessibilityCheckingUITestContextExtensions.cs
@@ -1,5 +1,6 @@
 using Deque.AxeCore.Commons;
 using Deque.AxeCore.Selenium;
+using Lombiq.Tests.UI.Constants;
 using Lombiq.Tests.UI.Exceptions;
 using Lombiq.Tests.UI.Helpers;
 using Lombiq.Tests.UI.Services;
@@ -48,13 +49,11 @@ public static class AccessibilityCheckingUITestContextExtensions
             var reportDirectoryPath = DirectoryHelper.CreateEnumeratedDirectory(
                 context.GetTempSubDirectoryPath("AxeHtmlReport"));
 
-            var reportPath = Path.Combine(
-                    reportDirectoryPath,
-                    context.TestManifest.Name.MakeFileSystemFriendly() + ".html");
+            var reportPath = Path.Combine(reportDirectoryPath, AccessibilityCheckingConstants.AccessibilityReportFileName);
 
             context.Driver.CreateAxeHtmlReport(axeResult, reportPath);
 
-            context.AppendTestDump(reportPath);
+            context.AppendTestDumpKeepingDuplicates(reportPath);
         }
     }
 

--- a/Lombiq.Tests.UI/Extensions/TestDumpUITestContextExtensions.cs
+++ b/Lombiq.Tests.UI/Extensions/TestDumpUITestContextExtensions.cs
@@ -108,6 +108,101 @@ public static class TestDumpUITestContextExtensions
             _ => Task.FromResult(image.ToStream()),
             messageIfExists: messageIfExists);
 
+    /// <summary>
+    /// Appends a local file's content to be collected in the test dump. Suffixes the file name with an index in case of
+    /// duplicates.
+    /// </summary>
+    /// <param name="filePath">The full file system path of the file.</param>
+    public static void AppendTestDumpKeepingDuplicates(
+        this UITestContext context,
+        string filePath) =>
+        context.AppendTestDumpKeepingDuplicatesInternal(
+            Path.GetFileName(filePath),
+            new TestDumpItem(() => Task.FromResult((Stream)File.OpenRead(filePath))));
+
+    /// <summary>
+    /// Appends stream as file content to be collected in the test dump. Suffixes the file name with an index in case of
+    /// duplicates.
+    /// </summary>
+    /// <param name="fileName">The name of the file.</param>
+    /// <param name="action">Gets called in test dump collection.</param>
+    public static void AppendTestDumpKeepingDuplicates(
+        this UITestContext context,
+        string fileName,
+        Func<UITestContext, Task<Stream>> action) =>
+        context.AppendTestDumpKeepingDuplicatesInternal(
+            fileName,
+            new TestDumpItem(() => action(context)));
+
+    /// <summary>
+    /// Appends string as file content to be collected in the test dump. Suffixes the file name with an index in case of
+    /// duplicates.
+    /// </summary>
+    /// <param name="fileName">The name of the file.</param>
+    /// <param name="content">File content.</param>
+    public static void AppendTestDumpKeepingDuplicates(
+        this UITestContext context,
+        string fileName,
+        string content) =>
+        context.AppendTestDumpKeepingDuplicatesInternal(
+            fileName,
+            new TestDumpItem(
+                () => Task.FromResult(
+                    new MemoryStream(
+                        Encoding.UTF8.GetBytes(content)) as Stream)));
+
+    /// <summary>
+    /// Appends generic content as file content to be collected in the test dump. Suffixes the file name with an index
+    /// in case of duplicates.
+    /// </summary>
+    /// <param name="fileName">The name of the file.</param>
+    /// <param name="content">File content.</param>
+    /// <param name="getStream">Function to get a new <see cref="Stream"/> from content.</param>
+    /// <param name="dispose">Action to dispose the content, if required. Can be null.</param>
+    public static void AppendTestDumpKeepingDuplicates<TContent>(
+        this UITestContext context,
+        string fileName,
+        TContent content,
+        Func<TContent, Task<Stream>> getStream,
+        Action<TContent> dispose = null) =>
+        context.AppendTestDumpKeepingDuplicatesInternal(
+            fileName,
+            new TestDumpItemGeneric<TContent>(content, getStream, dispose));
+
+    /// <summary>
+    /// Appends <see cref="Image"/> as file content to be collected in the test dump. Suffixes the file name with an
+    /// index in case of duplicates. The <see cref="Image"/> will be disposed at the end.
+    /// </summary>
+    /// <param name="fileName">The name of the file.</param>
+    /// <param name="image">File content. The <see cref="Image"/> will be disposed at the end.</param>
+    public static void AppendTestDumpKeepingDuplicates(
+        this UITestContext context,
+        string fileName,
+        Image image) => context
+        .AppendTestDumpKeepingDuplicates(
+            fileName,
+            image,
+            _ => Task.FromResult(image.ToStream()));
+
+    private static void AppendTestDumpKeepingDuplicatesInternal(
+        this UITestContext context,
+        string fileName,
+        ITestDumpItem item)
+    {
+        var fileNameWithoutExtension = Path.GetFileNameWithoutExtension(fileName);
+        var extension = Path.GetExtension(fileName);
+        var uniqueFileName = fileName;
+        var i = 0;
+
+        while (context.TestDumpContainer.ContainsKey(uniqueFileName))
+        {
+            i++;
+            uniqueFileName = $"{fileNameWithoutExtension}_{i.ToTechnicalString()}.{extension}";
+        }
+
+        context.AppendTestDumpInternal(uniqueFileName, item);
+    }
+
     private static void AppendTestDumpInternal(
         this UITestContext context,
         string fileName,

--- a/Lombiq.Tests.UI/Services/UITestExecutionSession.cs
+++ b/Lombiq.Tests.UI/Services/UITestExecutionSession.cs
@@ -824,7 +824,7 @@ internal sealed class UITestExecutionSession : IAsyncDisposable
                         " wasn't found. This most possibly means that the tenant's setup failed.");
                 }
 
-                var appSettings = JsonNode.Parse(await File.ReadAllTextAsync(appSettingsPath, _configuration.TestCancellationToken))!;
+                var appSettings = JsonNode.Parse(await File.ReadAllTextAsync(appSettingsPath, _configuration.TestCancellationToken));
                 appSettings[nameof(sqlServerContext.ConnectionString)] = sqlServerContext.ConnectionString;
                 await File.WriteAllTextAsync(appSettingsPath, appSettings.ToString(), _configuration.TestCancellationToken);
             }

--- a/Lombiq.Tests.UI/Services/UITestExecutionSession.cs
+++ b/Lombiq.Tests.UI/Services/UITestExecutionSession.cs
@@ -468,12 +468,13 @@ internal sealed class UITestExecutionSession : IAsyncDisposable
         if (ex is AccessibilityAssertionException accessibilityAssertionException
             && _configuration.AccessibilityCheckingConfiguration.CreateReportOnFailure)
         {
-            var accessibilityReportPath = Path.Combine(debugInformationPath, "AccessibilityReport.html");
+            var accessibilityReportPath = Path.Combine(debugInformationPath, AccessibilityCheckingConstants.AccessibilityReportFileName);
             _context.Driver.CreateAxeHtmlReport(accessibilityAssertionException.AxeResult, accessibilityReportPath);
 
             if (_configuration.ReportTeamCityMetadata)
             {
-                TeamCityMetadataReporter.ReportArtifactLink(_testManifest, "AccessibilityReport", accessibilityReportPath);
+                TeamCityMetadataReporter.ReportArtifactLink(
+                    _testManifest, AccessibilityCheckingConstants.AccessibilityReportFileNameWithoutExtension, accessibilityReportPath);
             }
         }
 


### PR DESCRIPTION
[NEST-644](https://lombiq.atlassian.net/browse/NEST-644)