### PR TITLE
OSOE-1272: Update dependencies: Browsers v148.0.7778.167, Microsoft.NET.Test.Sdk 18.5.1, Deque.AxeCore 4.11.3

### DIFF
--- a/Lombiq.Tests.UI.Samples/Lombiq.Tests.UI.Samples.csproj
+++ b/Lombiq.Tests.UI.Samples/Lombiq.Tests.UI.Samples.csproj
@@ -31,7 +31,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageReference Include="xunit.v3" Version="3.2.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>

--- a/Lombiq.Tests.UI/Lombiq.Tests.UI.csproj
+++ b/Lombiq.Tests.UI/Lombiq.Tests.UI.csproj
@@ -93,7 +93,7 @@
     <PackageReference Include="System.Linq.Async" Version="7.0.1" />
     <PackageReference Include="TWP.Selenium.Axe.Html" Version="1.0.0" />
     <PackageReference Include="xunit.v3.extensibility.core" Version="3.2.2" />
-    <PackageReference Include="YamlDotNet" Version="17.0.1" />
+    <PackageReference Include="YamlDotNet" Version="17.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Lombiq.Tests.UI/Lombiq.Tests.UI.csproj
+++ b/Lombiq.Tests.UI/Lombiq.Tests.UI.csproj
@@ -71,8 +71,8 @@
     <PackageReference Include="Azure.Storage.Blobs" Version="12.27.0" />
     <PackageReference Include="Ben.Demystifier" Version="0.4.1" />
     <PackageReference Include="Codeuctivity.ImageSharpCompare" Version="4.1.379" />
-    <PackageReference Include="Deque.AxeCore.Commons" Version="4.11.2" />
-    <PackageReference Include="Deque.AxeCore.Selenium" Version="4.11.2" />
+    <PackageReference Include="Deque.AxeCore.Commons" Version="4.11.3" />
+    <PackageReference Include="Deque.AxeCore.Selenium" Version="4.11.3" />
     <PackageReference Include="MailKit" Version="4.16.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
     <PackageReference Include="Microsoft.Web.LibraryManager.Build" Version="3.0.71" />

--- a/Lombiq.Tests.UI/Services/WebDriverFactory.cs
+++ b/Lombiq.Tests.UI/Services/WebDriverFactory.cs
@@ -37,7 +37,7 @@ public static class WebDriverFactory
             // is updated automatically by Renovate.
             // If anything on this line is changed, be sure to adjust the regex in the renovate.json5 config file in the
             // root too.
-            chromeConfig.Options.BrowserVersion = "148.0.7778.97";
+            chromeConfig.Options.BrowserVersion = "148.0.7778.167";
 
             configuration.BrowserOptionsConfigurator?.Invoke(chromeConfig.Options);
 

--- a/Lombiq.Tests.UI/Services/WebDriverFactory.cs
+++ b/Lombiq.Tests.UI/Services/WebDriverFactory.cs
@@ -68,17 +68,17 @@ public static class WebDriverFactory
             // root too.
             if (OperatingSystem.IsLinux())
             {
-                var linuxEdgeVersion = "147.0.3912.98";
+                var linuxEdgeVersion = "148.0.3967.54";
                 options.BrowserVersion = linuxEdgeVersion;
             }
             else if (OperatingSystem.IsWindows())
             {
-                var windowsEdgeVersion = "147.0.3912.98";
+                var windowsEdgeVersion = "148.0.3967.54";
                 options.BrowserVersion = windowsEdgeVersion;
             }
             else if (!OperatingSystem.IsMacOS())
             {
-                var macOsEdgeVersion = "147.0.3912.98";
+                var macOsEdgeVersion = "148.0.3967.54";
                 options.BrowserVersion = macOsEdgeVersion;
             }
 

--- a/Lombiq.Tests.UI/ui-testing-toolkit.mjs
+++ b/Lombiq.Tests.UI/ui-testing-toolkit.mjs
@@ -409,7 +409,7 @@ async function runTest(test, configureOptions = null) {
     // updated automatically by Renovate.
     // If anything on this line is changed, be sure to adjust the regex in the renovate.json5 config file in the root
     // too.
-    options.setBrowserVersion('148.0.7778.97');
+    options.setBrowserVersion('148.0.7778.167');
 
     console.log(`Using Chrome version ${options.getBrowserVersion()}.`);
 


### PR DESCRIPTION
Integrates Renovate dependency updates for [OSOE-1272](https://lombiq.atlassian.net/browse/OSOE-1272).

Merged renovate branches:
- \enovate/major-browsers\: Browsers → v148 (major version pin)
- \enovate/non-breaking-dependency-versions\: Microsoft.NET.Test.Sdk → 18.5.1
- \enovate/deque.axecore\: Deque.AxeCore → 4.11.3
- \enovate/browsers\: Chrome → 148.0.7778.167

[OSOE-1272]: https://lombiq.atlassian.net/browse/OSOE-1272?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ