### PR TITLE
OSOE-1285: Update dependencies: Edge 149.0.4022.62, Chrome 149.0.7827.55

### DIFF
--- a/Lombiq.Tests.UI/Services/WebDriverFactory.cs
+++ b/Lombiq.Tests.UI/Services/WebDriverFactory.cs
@@ -37,7 +37,7 @@ public static class WebDriverFactory
             // is updated automatically by Renovate.
             // If anything on this line is changed, be sure to adjust the regex in the renovate.json5 config file in the
             // root too.
-            chromeConfig.Options.BrowserVersion = "149.0.7827.54";
+            chromeConfig.Options.BrowserVersion = "149.0.7827.55";
 
             configuration.BrowserOptionsConfigurator?.Invoke(chromeConfig.Options);
 

--- a/Lombiq.Tests.UI/Services/WebDriverFactory.cs
+++ b/Lombiq.Tests.UI/Services/WebDriverFactory.cs
@@ -68,17 +68,17 @@ public static class WebDriverFactory
             // root too.
             if (OperatingSystem.IsLinux())
             {
-                var linuxEdgeVersion = "148.0.3967.96";
+                var linuxEdgeVersion = "149.0.4022.62";
                 options.BrowserVersion = linuxEdgeVersion;
             }
             else if (OperatingSystem.IsWindows())
             {
-                var windowsEdgeVersion = "148.0.3967.96";
+                var windowsEdgeVersion = "149.0.4022.62";
                 options.BrowserVersion = windowsEdgeVersion;
             }
             else if (!OperatingSystem.IsMacOS())
             {
-                var macOsEdgeVersion = "148.0.3967.96";
+                var macOsEdgeVersion = "149.0.4022.62";
                 options.BrowserVersion = macOsEdgeVersion;
             }
 

--- a/Lombiq.Tests.UI/ui-testing-toolkit.mjs
+++ b/Lombiq.Tests.UI/ui-testing-toolkit.mjs
@@ -409,7 +409,7 @@ async function runTest(test, configureOptions = null) {
     // updated automatically by Renovate.
     // If anything on this line is changed, be sure to adjust the regex in the renovate.json5 config file in the root
     // too.
-    options.setBrowserVersion('149.0.7827.54');
+    options.setBrowserVersion('149.0.7827.55');
 
     console.log(`Using Chrome version ${options.getBrowserVersion()}.`);
 


### PR DESCRIPTION
Integrates Renovate dependency updates for [OSOE-1285](https://lombiq.atlassian.net/browse/OSOE-1285).

[OSOE-1285]: https://lombiq.atlassian.net/browse/OSOE-1285?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ