### PR TITLE
OSOE-1296: Update dependencies: Browsers v150, Deque.AxeCore 4.12.0, Microsoft.NET.Test.Sdk 18.7.0

### DIFF
--- a/Lombiq.Tests.UI.Samples/Lombiq.Tests.UI.Samples.csproj
+++ b/Lombiq.Tests.UI.Samples/Lombiq.Tests.UI.Samples.csproj
@@ -31,7 +31,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageReference Include="xunit.v3" Version="3.2.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>

--- a/Lombiq.Tests.UI/Lombiq.Tests.UI.csproj
+++ b/Lombiq.Tests.UI/Lombiq.Tests.UI.csproj
@@ -85,7 +85,7 @@
     <PackageReference Include="OrchardCore.Logging.NLog" Version="2.1.0" />
     <PackageReference Include="OrchardCore.Abstractions" Version="2.1.0" />
     <PackageReference Include="OrchardCore.Recipes.Core" Version="2.1.0" />
-    <PackageReference Include="Sarif.Sdk" Version="5.0.10" />
+    <PackageReference Include="Sarif.Sdk" Version="5.4.0" />
     <!-- Referencing a newer version than what Atata uses, but not the latest version. See the comments in
     renovate.json5 for details. -->
     <PackageReference Include="Selenium.WebDriver" Version="4.38.0" />

--- a/Lombiq.Tests.UI/Lombiq.Tests.UI.csproj
+++ b/Lombiq.Tests.UI/Lombiq.Tests.UI.csproj
@@ -71,8 +71,8 @@
     <PackageReference Include="Azure.Storage.Blobs" Version="12.29.1" />
     <PackageReference Include="Ben.Demystifier" Version="0.4.1" />
     <PackageReference Include="Codeuctivity.ImageSharpCompare" Version="4.1.390" />
-    <PackageReference Include="Deque.AxeCore.Commons" Version="4.11.3" />
-    <PackageReference Include="Deque.AxeCore.Selenium" Version="4.11.3" />
+    <PackageReference Include="Deque.AxeCore.Commons" Version="4.12.0" />
+    <PackageReference Include="Deque.AxeCore.Selenium" Version="4.12.0" />
     <PackageReference Include="MailKit" Version="4.17.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
     <PackageReference Include="Microsoft.Web.LibraryManager.Build" Version="3.0.114" />

--- a/Lombiq.Tests.UI/Services/WebDriverFactory.cs
+++ b/Lombiq.Tests.UI/Services/WebDriverFactory.cs
@@ -37,7 +37,7 @@ public static class WebDriverFactory
             // is updated automatically by Renovate.
             // If anything on this line is changed, be sure to adjust the regex in the renovate.json5 config file in the
             // root too.
-            chromeConfig.Options.BrowserVersion = "150.0.7871.46";
+            chromeConfig.Options.BrowserVersion = "150.0.7871.115";
 
             configuration.BrowserOptionsConfigurator?.Invoke(chromeConfig.Options);
 
@@ -118,7 +118,7 @@ public static class WebDriverFactory
             // automatically by Renovate.
             // If anything on this line is changed, be sure to adjust the regex in the renovate.json5 config file in the
             // root too.
-            firefoxOptions.BrowserVersion = "152.0.4";
+            firefoxOptions.BrowserVersion = "152.0.5";
 
             if (configuration.Headless) firefoxOptions.AddArgument("--headless");
 

--- a/Lombiq.Tests.UI/Services/WebDriverFactory.cs
+++ b/Lombiq.Tests.UI/Services/WebDriverFactory.cs
@@ -68,17 +68,17 @@ public static class WebDriverFactory
             // root too.
             if (OperatingSystem.IsLinux())
             {
-                var linuxEdgeVersion = "149.0.4022.98";
+                var linuxEdgeVersion = "150.0.4078.48";
                 options.BrowserVersion = linuxEdgeVersion;
             }
             else if (OperatingSystem.IsWindows())
             {
-                var windowsEdgeVersion = "149.0.4022.98";
+                var windowsEdgeVersion = "150.0.4078.48";
                 options.BrowserVersion = windowsEdgeVersion;
             }
             else if (!OperatingSystem.IsMacOS())
             {
-                var macOsEdgeVersion = "149.0.4022.98";
+                var macOsEdgeVersion = "150.0.4078.50";
                 options.BrowserVersion = macOsEdgeVersion;
             }
 

--- a/Lombiq.Tests.UI/ui-testing-toolkit.mjs
+++ b/Lombiq.Tests.UI/ui-testing-toolkit.mjs
@@ -409,7 +409,7 @@ async function runTest(test, configureOptions = null) {
     // updated automatically by Renovate.
     // If anything on this line is changed, be sure to adjust the regex in the renovate.json5 config file in the root
     // too.
-    options.setBrowserVersion('150.0.7871.46');
+    options.setBrowserVersion('150.0.7871.115');
 
     console.log(`Using Chrome version ${options.getBrowserVersion()}.`);
 


### PR DESCRIPTION
Integrates Renovate dependency updates:
- Browsers updated to v150
- Deque.AxeCore updated to 4.12.0
- Microsoft.NET.Test.Sdk updated to 18.7.0

Jira issue: [OSOE-1296](https://lombiq.atlassian.net/browse/OSOE-1296)

[OSOE-1296]: https://lombiq.atlassian.net/browse/OSOE-1296?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ