### PR TITLE
OSOE-1299: Update dependencies: Browsers, Microsoft.Extensions.Diagnostics.Testing to 10.7.0; upgrade Microsoft.OpenApi to 2.11.0

### DIFF
--- a/Lombiq.Tests.UI.Samples/Lombiq.Tests.UI.Samples.csproj
+++ b/Lombiq.Tests.UI.Samples/Lombiq.Tests.UI.Samples.csproj
@@ -26,6 +26,12 @@
     <ProjectReference Include="..\Lombiq.Tests.UI\Lombiq.Tests.UI.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <!-- Microsoft.AspNetCore.DataProtection transitively pulls in System.Security.Cryptography.Xml 10.0.8, which has
+         a known high severity vulnerability (CVE-2026-47304); pin to the patched version. -->
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.10" />
+  </ItemGroup>
+
   <Import Condition="'$(NuGetBuild)' != 'true'" Project="../../../src/Utilities/Lombiq.MSBuild.Targets/Lombiq.MSBuild.OrchardCore.Tests.Sdk/Sdk/Import.targets" />
   <Import Condition="'$(NuGetBuild)' == 'true'" Project="Sdk.targets" Sdk="Lombiq.MSBuild.OrchardCore.Tests.Sdk" Version="2.0.1" />
 </Project>

--- a/Lombiq.Tests.UI.Shortcuts/Lombiq.Tests.UI.Shortcuts.csproj
+++ b/Lombiq.Tests.UI.Shortcuts/Lombiq.Tests.UI.Shortcuts.csproj
@@ -18,8 +18,15 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.10" />
-    <!-- Microsoft.OpenApi is required by Microsoft.AspNetCore.OpenApi, but its default version has a security vulnerability. -->
-    <PackageReference Include="Microsoft.OpenApi" Version="3.8.0" />
+    <!-- Microsoft.OpenApi is required by Microsoft.AspNetCore.OpenApi, but its default version has a security vulnerability.
+         Note: Staying on the 2.x line intentionally (upgraded to the latest patched 2.x release). Microsoft.OpenApi 3.x is
+         only supported starting with Microsoft.AspNetCore.OpenApi 11.x (ASP.NET Core 11, still in preview); using it here
+         breaks the Microsoft.AspNetCore.OpenApi.SourceGenerators-generated code (CS0200 on IOpenApiMediaType.Example,
+         which became read-only in 3.x). See https://learn.microsoft.com/aspnet/core/breaking-changes/11/microsoft-openapi-3x
+         and https://github.com/dotnet/aspnetcore/issues/67930. Once Microsoft.AspNetCore.OpenApi is upgraded to depend on
+         Microsoft.OpenApi >=3.0.0 (i.e., once it targets ASP.NET Core 11+ as stable), this direct PackageReference can be
+         removed and the transitive version will be safe by default. -->
+    <PackageReference Include="Microsoft.OpenApi" Version="2.11.0" />
     <PackageReference Include="OrchardCore.Users" Version="$(OrchardCoreVersion)" />
   </ItemGroup>
 

--- a/Lombiq.Tests.UI.Shortcuts/Lombiq.Tests.UI.Shortcuts.csproj
+++ b/Lombiq.Tests.UI.Shortcuts/Lombiq.Tests.UI.Shortcuts.csproj
@@ -19,7 +19,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.9" />
     <!-- Microsoft.OpenApi is required by Microsoft.AspNetCore.OpenApi, but its default version has a security vulnerability. -->
-    <PackageReference Include="Microsoft.OpenApi" Version="2.9.0" />
+    <PackageReference Include="Microsoft.OpenApi" Version="3.8.0" />
     <PackageReference Include="OrchardCore.Users" Version="$(OrchardCoreVersion)" />
   </ItemGroup>
 

--- a/Lombiq.Tests.UI.Shortcuts/Lombiq.Tests.UI.Shortcuts.csproj
+++ b/Lombiq.Tests.UI.Shortcuts/Lombiq.Tests.UI.Shortcuts.csproj
@@ -17,9 +17,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.9" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.10" />
     <!-- Microsoft.OpenApi is required by Microsoft.AspNetCore.OpenApi, but its default version has a security vulnerability. -->
-    <PackageReference Include="Microsoft.OpenApi" Version="2.9.0" />
+    <PackageReference Include="Microsoft.OpenApi" Version="2.10.0" />
     <PackageReference Include="OrchardCore.Users" Version="$(OrchardCoreVersion)" />
   </ItemGroup>
 

--- a/Lombiq.Tests.UI/Lombiq.Tests.UI.csproj
+++ b/Lombiq.Tests.UI/Lombiq.Tests.UI.csproj
@@ -41,7 +41,7 @@
     <PackageReference Include="Codeuctivity.ImageSharpCompare" Version="4.1.390" />
     <PackageReference Include="Deque.AxeCore.Selenium" Version="4.12.0" />
     <PackageReference Include="MailKit" Version="4.17.0" />
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.Testing" Version="10.4.0" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.Testing" Version="10.7.0" />
     <PackageReference Include="Microsoft.SqlServer.DACFx" Version="170.4.83" />
     <PackageReference Include="Microsoft.SqlServer.SqlManagementObjects" Version="181.25.0" />
     <PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0" />

--- a/Lombiq.Tests.UI/Lombiq.Tests.UI.csproj
+++ b/Lombiq.Tests.UI/Lombiq.Tests.UI.csproj
@@ -48,7 +48,7 @@
     <PackageReference Include="OrchardCore.Logging.NLog" Version="$(OrchardCoreVersion)" />
     <PackageReference Include="OrchardCore.Recipes.Core" Version="$(OrchardCoreVersion)" />
     <PackageReference Include="OrchardCore.Workflows" Version="$(OrchardCoreVersion)" />
-    <PackageReference Include="Sarif.Sdk" Version="5.4.3" />
+    <PackageReference Include="Sarif.Sdk" Version="5.5.0" />
     <!-- Referencing a newer version than what Atata uses, but not the latest version. See the comments in
     renovate.json5 for details. -->
     <PackageReference Include="TWP.Selenium.Axe.Html" Version="1.0.0" />

--- a/Lombiq.Tests.UI/Services/WebDriverFactory.cs
+++ b/Lombiq.Tests.UI/Services/WebDriverFactory.cs
@@ -37,7 +37,7 @@ public static class WebDriverFactory
             // is updated automatically by Renovate.
             // If anything on this line is changed, be sure to adjust the regex in the renovate.json5 config file in the
             // root too.
-            chromeConfig.Options.BrowserVersion = "151.0.7922.34";
+            chromeConfig.Options.BrowserVersion = "151.0.7922.47";
 
             configuration.BrowserOptionsConfigurator?.Invoke(chromeConfig.Options);
 
@@ -68,17 +68,17 @@ public static class WebDriverFactory
             // root too.
             if (OperatingSystem.IsLinux())
             {
-                var linuxEdgeVersion = "150.0.4078.65";
+                var linuxEdgeVersion = "150.0.4078.99";
                 options.BrowserVersion = linuxEdgeVersion;
             }
             else if (OperatingSystem.IsWindows())
             {
-                var windowsEdgeVersion = "150.0.4078.65";
+                var windowsEdgeVersion = "150.0.4078.99";
                 options.BrowserVersion = windowsEdgeVersion;
             }
             else if (!OperatingSystem.IsMacOS())
             {
-                var macOsEdgeVersion = "150.0.4078.65";
+                var macOsEdgeVersion = "150.0.4078.99";
                 options.BrowserVersion = macOsEdgeVersion;
             }
 

--- a/Lombiq.Tests.UI/Services/WebDriverFactory.cs
+++ b/Lombiq.Tests.UI/Services/WebDriverFactory.cs
@@ -118,7 +118,7 @@ public static class WebDriverFactory
             // automatically by Renovate.
             // If anything on this line is changed, be sure to adjust the regex in the renovate.json5 config file in the
             // root too.
-            firefoxOptions.BrowserVersion = "152.0.6";
+            firefoxOptions.BrowserVersion = "153.0";
 
             if (configuration.Headless) firefoxOptions.AddArgument("--headless");
 


### PR DESCRIPTION
Includes Renovate updates for Browsers, Microsoft.Extensions.Diagnostics.Testing 10.7.0, and non-breaking dependency versions. Microsoft.OpenApi is upgraded to 2.11.0 (latest patched 2.x) instead of the Renovate-proposed 3.x, since Microsoft.OpenApi 3.x is not yet supported by Microsoft.AspNetCore.OpenApi until net11 (breaks the XmlCommentGenerator source generator, see dotnet/aspnetcore#67930). Once Microsoft.AspNetCore.OpenApi supports Microsoft.OpenApi >=3.0.0, the direct Microsoft.OpenApi reference can be removed.

Jira: [OSOE-1299](https://lombiq.atlassian.net/browse/OSOE-1299)

[OSOE-1299]: https://lombiq.atlassian.net/browse/OSOE-1299?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ