### PR TITLE
OSOE-1299: Centralizing System.Security.Cryptography.Xml reference necessary to fix transitive dependency vulnerability in Lombiq.Tests.UI

### DIFF
--- a/Lombiq.Tests.UI.Samples/Lombiq.Tests.UI.Samples.csproj
+++ b/Lombiq.Tests.UI.Samples/Lombiq.Tests.UI.Samples.csproj
@@ -26,12 +26,6 @@
     <ProjectReference Include="..\Lombiq.Tests.UI\Lombiq.Tests.UI.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <!-- Microsoft.AspNetCore.DataProtection transitively pulls in System.Security.Cryptography.Xml 10.0.8, which has
-         a known high severity vulnerability (CVE-2026-47304); pin to the patched version. -->
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.10" />
-  </ItemGroup>
-
   <Import Condition="'$(NuGetBuild)' != 'true'" Project="../../../src/Utilities/Lombiq.MSBuild.Targets/Lombiq.MSBuild.OrchardCore.Tests.Sdk/Sdk/Import.targets" />
   <Import Condition="'$(NuGetBuild)' == 'true'" Project="Sdk.targets" Sdk="Lombiq.MSBuild.OrchardCore.Tests.Sdk" Version="2.0.1" />
 </Project>

--- a/Lombiq.Tests.UI/Lombiq.Tests.UI.csproj
+++ b/Lombiq.Tests.UI/Lombiq.Tests.UI.csproj
@@ -53,7 +53,12 @@
     renovate.json5 for details. -->
     <PackageReference Include="TWP.Selenium.Axe.Html" Version="1.0.0" />
     <PackageReference Include="YamlDotNet" Version="18.1.0" />
+    <!-- Microsoft.AspNetCore.DataProtection transitively pulls in System.Security.Cryptography.Xml 10.0.8, which has
+         a known high severity vulnerability (CVE-2026-47304); pin to the patched version. This can be removed once
+         Microsoft.AspNetCore.DataProtection is updated. -->
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.10" />
   </ItemGroup>
+  
 
   <ItemGroup>
     <ProjectReference Include="..\Lombiq.Tests.UI.AppExtensions\Lombiq.Tests.UI.AppExtensions.csproj" />


### PR DESCRIPTION
[OSOE-1299](https://lombiq.atlassian.net/browse/OSOE-1299)

[OSOE-1299]: https://lombiq.atlassian.net/browse/OSOE-1299?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ