### PR TITLE
OSOE-1303: Update dependencies: Browser versions, Microsoft.Extensions.Diagnostics.Testing 10.8.0, pin Microsoft.OpenApi to 2.x

### DIFF
--- a/Lombiq.Tests.UI.Shortcuts/Lombiq.Tests.UI.Shortcuts.csproj
+++ b/Lombiq.Tests.UI.Shortcuts/Lombiq.Tests.UI.Shortcuts.csproj
@@ -25,7 +25,8 @@
          which became read-only in 3.x). See https://learn.microsoft.com/aspnet/core/breaking-changes/11/microsoft-openapi-3x
          and https://github.com/dotnet/aspnetcore/issues/67930. Once Microsoft.AspNetCore.OpenApi is upgraded to depend on
          Microsoft.OpenApi >=3.0.0 (i.e., once it targets ASP.NET Core 11+ as stable), this direct PackageReference can be
-         removed and the transitive version will be safe by default. -->
+         removed and the transitive version will be safe by default.
+         Once this reference is removed, also remove the corresponding config from renovate.json5. -->
     <PackageReference Include="Microsoft.OpenApi" Version="2.11.0" />
     <PackageReference Include="OrchardCore.Users" Version="$(OrchardCoreVersion)" />
   </ItemGroup>

--- a/Lombiq.Tests.UI/Lombiq.Tests.UI.csproj
+++ b/Lombiq.Tests.UI/Lombiq.Tests.UI.csproj
@@ -41,7 +41,7 @@
     <PackageReference Include="Codeuctivity.ImageSharpCompare" Version="4.1.390" />
     <PackageReference Include="Deque.AxeCore.Selenium" Version="4.12.0" />
     <PackageReference Include="MailKit" Version="4.17.0" />
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.Testing" Version="10.7.0" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.Testing" Version="10.8.0" />
     <PackageReference Include="Microsoft.SqlServer.DACFx" Version="170.4.83" />
     <PackageReference Include="Microsoft.SqlServer.SqlManagementObjects" Version="181.25.0" />
     <PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0" />

--- a/Lombiq.Tests.UI/Services/WebDriverFactory.cs
+++ b/Lombiq.Tests.UI/Services/WebDriverFactory.cs
@@ -37,7 +37,7 @@ public static class WebDriverFactory
             // is updated automatically by Renovate.
             // If anything on this line is changed, be sure to adjust the regex in the renovate.json5 config file in the
             // root too.
-            chromeConfig.Options.BrowserVersion = "151.0.7922.47";
+            chromeConfig.Options.BrowserVersion = "151.0.7922.71";
 
             configuration.BrowserOptionsConfigurator?.Invoke(chromeConfig.Options);
 
@@ -68,17 +68,17 @@ public static class WebDriverFactory
             // root too.
             if (OperatingSystem.IsLinux())
             {
-                var linuxEdgeVersion = "150.0.4078.99";
+                var linuxEdgeVersion = "150.0.4078.105";
                 options.BrowserVersion = linuxEdgeVersion;
             }
             else if (OperatingSystem.IsWindows())
             {
-                var windowsEdgeVersion = "150.0.4078.99";
+                var windowsEdgeVersion = "150.0.4078.105";
                 options.BrowserVersion = windowsEdgeVersion;
             }
             else if (!OperatingSystem.IsMacOS())
             {
-                var macOsEdgeVersion = "150.0.4078.99";
+                var macOsEdgeVersion = "150.0.4078.105";
                 options.BrowserVersion = macOsEdgeVersion;
             }
 

--- a/renovate.json5
+++ b/renovate.json5
@@ -50,6 +50,14 @@
             enabled: false,
         },
         {
+            matchPackageNames: [
+                'Microsoft.OpenApi',
+            ],
+            // Keep Microsoft.OpenApi on version 2.x. See the corresponding comment in Lombiq.Tests.UI.Shortcuts.csproj
+            // for details.
+            allowedVersions: '< 3.0.0',
+        },
+        {
             // No groupName, because we don't want these updates to be in their own groups, just want to add the note.
             // Otherwise, the release is not linked for this package.
             matchPackageNames: [


### PR DESCRIPTION
Updates dependency versions and adds Renovate config to prevent Microsoft.OpenApi 3.x upgrades.

Changes:
- Merge renovate/browsers: Update browser versions
- Merge renovate/microsoft.extensions: Microsoft.Extensions.Diagnostics.Testing → 10.8.0
- Add Renovate package rule to pin Microsoft.OpenApi to 2.x (< 3.0.0) due to ASP.NET Core 11+ requirement

Related to: [OSOE-1303](https://lombiq.atlassian.net/browse/OSOE-1303)

[OSOE-1303]: https://lombiq.atlassian.net/browse/OSOE-1303?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ