### PR TITLE
Fix smtp4dev startup on Linux; add OS port availability check; update Browsers to v151, Atata 3.11.0 -> 3.12.0

### DIFF
--- a/Lombiq.Tests.UI/AccessibilityChecking/AxeHtmlReport.cs
+++ b/Lombiq.Tests.UI/AccessibilityChecking/AxeHtmlReport.cs
@@ -29,6 +29,7 @@ public enum AxeReportTypes
 
 // After upgrading from .NET 10, and thus releasing a breaking version, move all accessibility-related code to this
 // namespace.
+
 /// <summary>
 /// Generates standalone HTML reports from Axe results.
 /// </summary>
@@ -432,12 +433,11 @@ public static class AxeHtmlReport
     private static string LoadEmbeddedResource(string name)
     {
         using var stream = typeof(AxeHtmlReport).Assembly
-            .GetManifestResourceStream($"Lombiq.Tests.UI.AccessibilityChecking.{name}");
-        if (stream is null) throw new InvalidOperationException($"Embedded resource '{name}' not found.");
+            .GetManifestResourceStream($"Lombiq.Tests.UI.AccessibilityChecking.{name}")
+            ?? throw new InvalidOperationException($"Embedded resource '{name}' not found.");
         using var reader = new StreamReader(stream);
         return reader.ReadToEnd();
     }
 
     private static readonly string Js = LoadEmbeddedResource("AxeHtmlReport.js");
 }
-

--- a/Lombiq.Tests.UI/Lombiq.Tests.UI.csproj
+++ b/Lombiq.Tests.UI/Lombiq.Tests.UI.csproj
@@ -37,10 +37,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Atata" Version="3.11.0" />
+    <PackageReference Include="Atata" Version="3.12.0" />
     <PackageReference Include="Atata.Bootstrap" Version="3.1.0" />
     <PackageReference Include="Atata.HtmlValidation" Version="3.5.0" />
-    <PackageReference Include="Atata.WebDriverExtras" Version="3.7.0" />
+    <PackageReference Include="Atata.WebDriverExtras" Version="3.8.0" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.29.1" />
     <PackageReference Include="Ben.Demystifier" Version="0.4.1" />
     <PackageReference Include="Codeuctivity.ImageSharpCompare" Version="4.1.390" />

--- a/Lombiq.Tests.UI/Services/PortLeaseManager.cs
+++ b/Lombiq.Tests.UI/Services/PortLeaseManager.cs
@@ -39,9 +39,8 @@ public class PortLeaseManager
 
         try
         {
-            // Filter out ports already leased by this process AND ports already in use by the OS (e.g., from other
-            // processes on the runner). This prevents smtp4dev and similar services from failing to bind because
-            // another process has already claimed the port.
+            // Filter out ports already leased by this process AND ports already in use by the OS. This prevents
+            // smtp4dev and similar services from failing to bind because another process has already claimed the port.
             var availablePorts = _availablePortsRange
                 .Except(_usedPorts)
                 .Where(IsPortFreeOnOs)

--- a/Lombiq.Tests.UI/Services/PortLeaseManager.cs
+++ b/Lombiq.Tests.UI/Services/PortLeaseManager.cs
@@ -3,6 +3,8 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Net;
+using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -37,7 +39,13 @@ public class PortLeaseManager
 
         try
         {
-            var availablePorts = _availablePortsRange.Except(_usedPorts).ToList();
+            // Filter out ports already leased by this process AND ports already in use by the OS (e.g., from other
+            // processes on the runner). This prevents smtp4dev and similar services from failing to bind because
+            // another process has already claimed the port.
+            var availablePorts = _availablePortsRange
+                .Except(_usedPorts)
+                .Where(IsPortFreeOnOs)
+                .ToList();
 
             if (availablePorts.Count == 0)
             {
@@ -62,5 +70,20 @@ public class PortLeaseManager
         _usedPorts.Remove(port);
 
         _portAcquisitionLock.Release();
+    }
+
+    private static bool IsPortFreeOnOs(int port)
+    {
+        try
+        {
+            using var listener = new TcpListener(IPAddress.Loopback, port);
+            listener.Start();
+            listener.Stop();
+            return true;
+        }
+        catch (SocketException)
+        {
+            return false;
+        }
     }
 }

--- a/Lombiq.Tests.UI/Services/PortLeaseManager.cs
+++ b/Lombiq.Tests.UI/Services/PortLeaseManager.cs
@@ -3,8 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
-using System.Net;
-using System.Net.Sockets;
+using System.Net.NetworkInformation;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -71,18 +70,6 @@ public class PortLeaseManager
         _portAcquisitionLock.Release();
     }
 
-    private static bool IsPortFreeOnOs(int port)
-    {
-        try
-        {
-            using var listener = new TcpListener(IPAddress.Loopback, port);
-            listener.Start();
-            listener.Stop();
-            return true;
-        }
-        catch (SocketException)
-        {
-            return false;
-        }
-    }
+    private static bool IsPortFreeOnOs(int port) =>
+        !IPGlobalProperties.GetIPGlobalProperties().GetActiveTcpListeners().Any(endPoint => endPoint.Port == port);
 }

--- a/Lombiq.Tests.UI/Services/SmtpService.cs
+++ b/Lombiq.Tests.UI/Services/SmtpService.cs
@@ -193,7 +193,7 @@ public sealed class SmtpService : IAsyncDisposable
 
     private static async Task WaitForSmtpPortAsync(int port, CancellationToken cancellationToken)
     {
-        const int maxAttempts = 40;
+        const int maxAttempts = 120;
         const int delayMilliseconds = 250;
 
         for (var attempt = 0; attempt < maxAttempts; attempt++)
@@ -220,7 +220,7 @@ public sealed class SmtpService : IAsyncDisposable
 
     private static async Task WaitForImapPortAsync(int port, CancellationToken cancellationToken)
     {
-        const int maxAttempts = 40;
+        const int maxAttempts = 120;
         const int delayMilliseconds = 250;
 
         for (var attempt = 0; attempt < maxAttempts; attempt++)

--- a/Lombiq.Tests.UI/Services/SmtpService.cs
+++ b/Lombiq.Tests.UI/Services/SmtpService.cs
@@ -42,6 +42,7 @@ public sealed class SmtpService : IAsyncDisposable
 
     private readonly SmtpServiceConfiguration _configuration;
     private readonly CancellationTokenSource _cancellationTokenSource = new();
+    private readonly SemaphoreSlim _smtpExited = new(0, 1);
 
     private static bool _wasRestored;
 
@@ -134,8 +135,8 @@ public sealed class SmtpService : IAsyncDisposable
                 $"web UI port {webUIPortString}, IMAP port {_imapPort.ToTechnicalString()}, and POP3 port " +
                 $"{_pop3Port.ToTechnicalString()} due to the following error:{Environment.NewLine}{line}")));
 
-        // Fire-and-forget: smtp4dev runs until the CancellationToken is canceled in DisposeAsync. Not awaiting keeps
-        // the stdout pipe alive so smtp4dev's SMTP/IMAP listeners can start after the HTTP host signals readiness.
+        // Not awaiting keeps the stdout pipe alive so smtp4dev's SMTP/IMAP listeners can start after the HTTP host
+        // signals readiness. The continuation releases _smtpExited so DisposeAsync knows the ports have been freed.
         _ = CliProgram.DotNet
             .GetCommand(
                 "tool",
@@ -159,7 +160,8 @@ public sealed class SmtpService : IAsyncDisposable
             .WithStandardOutputPipe(stdOutPipe)
             .WithStandardErrorPipe(stdErrPipe)
             .WithValidation(CommandResultValidation.None)
-            .ExecuteAsync(token);
+            .ExecuteAsync(token)
+            .Task.ContinueWith(_ => _smtpExited.Release(), TaskScheduler.Default);
 
         await startedTcs.Task.WaitAsync(TimeSpan.FromSeconds(30), token);
 
@@ -178,12 +180,11 @@ public sealed class SmtpService : IAsyncDisposable
 
         _isDisposed = true;
 
-        // Cancel the token first to signal smtp4dev to exit, then wait briefly to ensure the process has released
-        // its ports before we mark them as available for the next test's smtp4dev instance.
         await _cancellationTokenSource.CancelAsync();
         _cancellationTokenSource.Dispose();
-
-        await Task.Delay(500, CancellationToken.None);
+        // Wait until the process exits so ports are guaranteed to be released before we return them to the lease pool.
+        await _smtpExited.WaitAsync(TimeSpan.FromSeconds(15), CancellationToken.None);
+        _smtpExited.Dispose();
 
         // This is a clean-up method, no need to forward a CancellationToken.
         await _smtpPortLeaseManager.StopLeaseAsync(_smtpPort, CancellationToken.None);

--- a/Lombiq.Tests.UI/Services/SmtpService.cs
+++ b/Lombiq.Tests.UI/Services/SmtpService.cs
@@ -5,7 +5,6 @@ using MailKit.Net.Smtp;
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Net.Sockets;
 using System.Text.Json.Nodes;
 using System.Threading;
@@ -111,18 +110,6 @@ public sealed class SmtpService : IAsyncDisposable
             _restoreSemaphore.Release();
         }
 
-        // The "splash screen" lines smtp4dev outputs to stderr on startup:
-        // https://github.com/rnwood/smtp4dev/issues/1996.
-        string[] splashScreenStdErrLineStarts = [
-            "┌────────────.",
-            "|\\          / \\",
-            "| \\        /   \\",
-            "|  smtp4dev    /",
-            "|             /",
-            "└────────────'",
-            " > For help use argument --help"
-            ];
-
         // Starting smtp4dev with a command similar to this (with more parameters, see below):
         // dotnet tool run smtp4dev --db "" --smtpport 11308 --urls http://localhost:12360/
         // An empty db parameter means an in-memory DB. For all possible command line arguments see:
@@ -142,18 +129,10 @@ public sealed class SmtpService : IAsyncDisposable
         });
 
         var stdErrPipe = PipeTarget.ToDelegate(line =>
-        {
-            if (splashScreenStdErrLineStarts.Any(stdErrLineStart => line.StartsWithOrdinal(stdErrLineStart)) ||
-                string.IsNullOrWhiteSpace(line))
-            {
-                return;
-            }
-
             startedTcs.TrySetException(new IOException(
                 $"The smtp4dev service didn't start properly on SMTP port {_smtpPort.ToTechnicalString()}, " +
                 $"web UI port {webUIPortString}, IMAP port {_imapPort.ToTechnicalString()}, and POP3 port " +
-                $"{_pop3Port.ToTechnicalString()} due to the following error:{Environment.NewLine}{line}"));
-        });
+                $"{_pop3Port.ToTechnicalString()} due to the following error:{Environment.NewLine}{line}")));
 
         // Fire-and-forget: smtp4dev runs until the CancellationToken is canceled in DisposeAsync. Not awaiting keeps
         // the stdout pipe alive so smtp4dev's SMTP/IMAP listeners can start after the HTTP host signals readiness.

--- a/Lombiq.Tests.UI/Services/SmtpService.cs
+++ b/Lombiq.Tests.UI/Services/SmtpService.cs
@@ -133,7 +133,7 @@ public sealed class SmtpService : IAsyncDisposable
         // stdout and causing the process to crash or hang before its SMTP/IMAP listeners ever start.
         var startedTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
-        var stdOutPipe = PipeTarget.ToDelegate((string line) =>
+        var stdOutPipe = PipeTarget.ToDelegate(line =>
         {
             if (line.Contains("Now listening on:", StringComparison.OrdinalIgnoreCase))
             {
@@ -141,7 +141,7 @@ public sealed class SmtpService : IAsyncDisposable
             }
         });
 
-        var stdErrPipe = PipeTarget.ToDelegate((string line) =>
+        var stdErrPipe = PipeTarget.ToDelegate(line =>
         {
             if (splashScreenStdErrLineStarts.Any(stdErrLineStart => line.StartsWithOrdinal(stdErrLineStart)) ||
                 string.IsNullOrWhiteSpace(line))

--- a/Lombiq.Tests.UI/Services/SmtpService.cs
+++ b/Lombiq.Tests.UI/Services/SmtpService.cs
@@ -1,5 +1,7 @@
 using CliWrap;
 using Lombiq.HelpfulLibraries.Cli;
+using MailKit.Net.Imap;
+using MailKit.Net.Smtp;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -163,10 +165,10 @@ public sealed class SmtpService : IAsyncDisposable
                 token);
 
         // smtp4dev's HTTP host signals readiness with "Now listening on:", but its SMTP and IMAP listeners may bind
-        // their ports asynchronously afterwards. We must verify these ports are actually accepting TCP connections
-        // before returning, to avoid "Connection refused" errors in tests.
-        await WaitForTcpPortAsync(_smtpPort, token);
-        await WaitForTcpPortAsync(_imapPort, token);
+        // their ports asynchronously afterwards. We use MailKit clients to probe these ports so that the probe itself
+        // performs a proper protocol handshake (not just a bare TCP connect) and doesn't leave smtp4dev in a bad state.
+        await WaitForSmtpPortAsync(_smtpPort, token);
+        await WaitForImapPortAsync(_imapPort, token);
 
         return new SmtpServiceRunningContext(_smtpPort, _imapPort, webUIUri);
     }
@@ -177,15 +179,19 @@ public sealed class SmtpService : IAsyncDisposable
 
         _isDisposed = true;
 
+        // Cancel the token first to signal smtp4dev to exit, then wait briefly to ensure the process has released
+        // its ports before we mark them as available for the next test's smtp4dev instance.
+        await _cancellationTokenSource.CancelAsync();
+        _cancellationTokenSource.Dispose();
+
+        await Task.Delay(500, CancellationToken.None);
+
         // This is a clean-up method, no need to forward a CancellationToken.
         await _smtpPortLeaseManager.StopLeaseAsync(_smtpPort, CancellationToken.None);
         await _webUIPortLeaseManager.StopLeaseAsync(_webUIPort, CancellationToken.None);
-
-        await _cancellationTokenSource.CancelAsync();
-        _cancellationTokenSource.Dispose();
     }
 
-    private static async Task WaitForTcpPortAsync(int port, CancellationToken cancellationToken)
+    private static async Task WaitForSmtpPortAsync(int port, CancellationToken cancellationToken)
     {
         const int maxAttempts = 40;
         const int delayMilliseconds = 250;
@@ -194,16 +200,44 @@ public sealed class SmtpService : IAsyncDisposable
         {
             try
             {
-                using var tcpClient = new TcpClient();
-                await tcpClient.ConnectAsync("localhost", port, cancellationToken);
+                using var client = new SmtpClient();
+                await client.ConnectAsync("localhost", port, useSsl: false, cancellationToken);
+                await client.DisconnectAsync(quit: true, cancellationToken);
                 return;
             }
-            catch (SocketException)
+            catch (Exception ex) when (ex is SocketException or SmtpCommandException or SmtpProtocolException or IOException)
             {
                 if (attempt == maxAttempts - 1)
                 {
                     throw new TimeoutException(
-                        $"The smtp4dev TCP port {port.ToTechnicalString()} did not become available within the expected time.");
+                        $"The smtp4dev SMTP port {port.ToTechnicalString()} did not become available within the expected time.");
+                }
+
+                await Task.Delay(delayMilliseconds, cancellationToken);
+            }
+        }
+    }
+
+    private static async Task WaitForImapPortAsync(int port, CancellationToken cancellationToken)
+    {
+        const int maxAttempts = 40;
+        const int delayMilliseconds = 250;
+
+        for (var attempt = 0; attempt < maxAttempts; attempt++)
+        {
+            try
+            {
+                using var client = new ImapClient();
+                await client.ConnectAsync("localhost", port, useSsl: false, cancellationToken);
+                await client.DisconnectAsync(quit: true, cancellationToken);
+                return;
+            }
+            catch (Exception ex) when (ex is SocketException or ImapCommandException or ImapProtocolException or IOException)
+            {
+                if (attempt == maxAttempts - 1)
+                {
+                    throw new TimeoutException(
+                        $"The smtp4dev IMAP port {port.ToTechnicalString()} did not become available within the expected time.");
                 }
 
                 await Task.Delay(delayMilliseconds, cancellationToken);

--- a/Lombiq.Tests.UI/Services/SmtpService.cs
+++ b/Lombiq.Tests.UI/Services/SmtpService.cs
@@ -127,7 +127,37 @@ public sealed class SmtpService : IAsyncDisposable
         // dotnet tool run smtp4dev --db "" --smtpport 11308 --urls http://localhost:12360/
         // An empty db parameter means an in-memory DB. For all possible command line arguments see:
         // https://github.com/rnwood/smtp4dev/blob/master/Rnwood.Smtp4dev/CommandLineParser.cs.
-        await CliProgram.DotNet
+        //
+        // We use PipeTarget.ToDelegate + a TaskCompletionSource instead of ExecuteUntilOutputAsync because returning
+        // early from ExecuteUntilOutputAsync's await foreach disposes CliWrap's stdout pipe, breaking smtp4dev's
+        // stdout and causing the process to crash or hang before its SMTP/IMAP listeners ever start.
+        var startedTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var stdOutPipe = PipeTarget.ToDelegate((string line) =>
+        {
+            if (line.Contains("Now listening on:", StringComparison.OrdinalIgnoreCase))
+            {
+                startedTcs.TrySetResult(true);
+            }
+        });
+
+        var stdErrPipe = PipeTarget.ToDelegate((string line) =>
+        {
+            if (splashScreenStdErrLineStarts.Any(stdErrLineStart => line.StartsWithOrdinal(stdErrLineStart)) ||
+                string.IsNullOrWhiteSpace(line))
+            {
+                return;
+            }
+
+            startedTcs.TrySetException(new IOException(
+                $"The smtp4dev service didn't start properly on SMTP port {_smtpPort.ToTechnicalString()}, " +
+                $"web UI port {webUIPortString}, IMAP port {_imapPort.ToTechnicalString()}, and POP3 port " +
+                $"{_pop3Port.ToTechnicalString()} due to the following error:{Environment.NewLine}{line}"));
+        });
+
+        // Fire-and-forget: smtp4dev runs until the CancellationToken is cancelled in DisposeAsync. Not awaiting keeps
+        // the stdout pipe alive so smtp4dev's SMTP/IMAP listeners can start after the HTTP host signals readiness.
+        _ = CliProgram.DotNet
             .GetCommand(
                 "tool",
                 "run",
@@ -147,22 +177,12 @@ public sealed class SmtpService : IAsyncDisposable
             {
                 ["ServerOptions__DisableMessageSanitisation"] = "true",
             })
-            .ExecuteUntilOutputAsync(
-                "Now listening on:",
-                stdErr =>
-                {
-                    if (splashScreenStdErrLineStarts.Any(stdErrLineStart => stdErr.Text.StartsWithOrdinal(stdErrLineStart)) ||
-                        string.IsNullOrWhiteSpace(stdErr.Text))
-                    {
-                        return;
-                    }
+            .WithStandardOutputPipe(stdOutPipe)
+            .WithStandardErrorPipe(stdErrPipe)
+            .WithValidation(CommandResultValidation.None)
+            .ExecuteAsync(token);
 
-                    throw new IOException(
-                        $"The smtp4dev service didn't start properly on SMTP port {_smtpPort.ToTechnicalString()}, " +
-                        $"web UI port {webUIPortString}, IMAP port {_imapPort.ToTechnicalString()}, and POP3 port " +
-                        $"{_pop3Port.ToTechnicalString()} due to the following error:{Environment.NewLine}{stdErr.Text}");
-                },
-                token);
+        await startedTcs.Task.WaitAsync(TimeSpan.FromSeconds(30), token);
 
         // smtp4dev's HTTP host signals readiness with "Now listening on:", but its SMTP and IMAP listeners may bind
         // their ports asynchronously afterwards. We use MailKit clients to probe these ports so that the probe itself

--- a/Lombiq.Tests.UI/Services/SmtpService.cs
+++ b/Lombiq.Tests.UI/Services/SmtpService.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Net.Sockets;
 using System.Text.Json.Nodes;
 using System.Threading;
 using System.Threading.Tasks;
@@ -161,6 +162,12 @@ public sealed class SmtpService : IAsyncDisposable
                 },
                 token);
 
+        // smtp4dev's HTTP host signals readiness with "Now listening on:", but its SMTP and IMAP listeners may bind
+        // their ports asynchronously afterwards. We must verify these ports are actually accepting TCP connections
+        // before returning, to avoid "Connection refused" errors in tests.
+        await WaitForTcpPortAsync(_smtpPort, token);
+        await WaitForTcpPortAsync(_imapPort, token);
+
         return new SmtpServiceRunningContext(_smtpPort, _imapPort, webUIUri);
     }
 
@@ -176,5 +183,31 @@ public sealed class SmtpService : IAsyncDisposable
 
         await _cancellationTokenSource.CancelAsync();
         _cancellationTokenSource.Dispose();
+    }
+
+    private static async Task WaitForTcpPortAsync(int port, CancellationToken cancellationToken)
+    {
+        const int maxAttempts = 40;
+        const int delayMilliseconds = 250;
+
+        for (var attempt = 0; attempt < maxAttempts; attempt++)
+        {
+            try
+            {
+                using var tcpClient = new TcpClient();
+                await tcpClient.ConnectAsync("localhost", port, cancellationToken);
+                return;
+            }
+            catch (SocketException)
+            {
+                if (attempt == maxAttempts - 1)
+                {
+                    throw new TimeoutException(
+                        $"The smtp4dev TCP port {port.ToTechnicalString()} did not become available within the expected time.");
+                }
+
+                await Task.Delay(delayMilliseconds, cancellationToken);
+            }
+        }
     }
 }

--- a/Lombiq.Tests.UI/Services/SmtpService.cs
+++ b/Lombiq.Tests.UI/Services/SmtpService.cs
@@ -155,7 +155,7 @@ public sealed class SmtpService : IAsyncDisposable
                 $"{_pop3Port.ToTechnicalString()} due to the following error:{Environment.NewLine}{line}"));
         });
 
-        // Fire-and-forget: smtp4dev runs until the CancellationToken is cancelled in DisposeAsync. Not awaiting keeps
+        // Fire-and-forget: smtp4dev runs until the CancellationToken is canceled in DisposeAsync. Not awaiting keeps
         // the stdout pipe alive so smtp4dev's SMTP/IMAP listeners can start after the HTTP host signals readiness.
         _ = CliProgram.DotNet
             .GetCommand(

--- a/Lombiq.Tests.UI/Services/UITestExecutionSession.cs
+++ b/Lombiq.Tests.UI/Services/UITestExecutionSession.cs
@@ -1,7 +1,7 @@
 using Atata.HtmlValidation;
 using Cysharp.Text;
-using Lombiq.Tests.UI.AccessibilityChecking;
 using Lombiq.HelpfulLibraries.Common.Utilities;
+using Lombiq.Tests.UI.AccessibilityChecking;
 using Lombiq.Tests.UI.Constants;
 using Lombiq.Tests.UI.Exceptions;
 using Lombiq.Tests.UI.Extensions;

--- a/Lombiq.Tests.UI/Services/WebDriverFactory.cs
+++ b/Lombiq.Tests.UI/Services/WebDriverFactory.cs
@@ -37,7 +37,7 @@ public static class WebDriverFactory
             // is updated automatically by Renovate.
             // If anything on this line is changed, be sure to adjust the regex in the renovate.json5 config file in the
             // root too.
-            chromeConfig.Options.BrowserVersion = "151.0.7922.71";
+            chromeConfig.Options.BrowserVersion = "151.0.7922.76";
 
             configuration.BrowserOptionsConfigurator?.Invoke(chromeConfig.Options);
 

--- a/Lombiq.Tests.UI/Services/WebDriverFactory.cs
+++ b/Lombiq.Tests.UI/Services/WebDriverFactory.cs
@@ -68,17 +68,17 @@ public static class WebDriverFactory
             // root too.
             if (OperatingSystem.IsLinux())
             {
-                var linuxEdgeVersion = "150.0.4078.105";
+                var linuxEdgeVersion = "151.0.4129.59";
                 options.BrowserVersion = linuxEdgeVersion;
             }
             else if (OperatingSystem.IsWindows())
             {
-                var windowsEdgeVersion = "150.0.4078.105";
+                var windowsEdgeVersion = "151.0.4129.59";
                 options.BrowserVersion = windowsEdgeVersion;
             }
             else if (!OperatingSystem.IsMacOS())
             {
-                var macOsEdgeVersion = "150.0.4078.105";
+                var macOsEdgeVersion = "151.0.4129.59";
                 options.BrowserVersion = macOsEdgeVersion;
             }
 


### PR DESCRIPTION
Fixes email test failures (`BehaviorEmailClientTests.ImapEmailFetchingShouldWork`, `BehaviorEmailQuotaTests.EmailQuotaShouldNotBeEnforcedWhenUsingCustomSmtpConfiguration`) on the warp runner. Jira issue: OSOE-1307.

**SmtpService** (root cause fix): `ExecuteUntilOutputAsync` used `await foreach` over CliWrap's `ListenAsync`. Returning early after detecting smtp4dev's startup line disposed the `IAsyncEnumerator`, breaking the stdout pipe on Linux and crashing smtp4dev before its SMTP/IMAP listeners bound. Replaced with `PipeTarget.ToDelegate` + `TaskCompletionSource` so smtp4dev runs fire-and-forget via `Command.ExecuteAsync(token)` with the pipe kept alive. Also switched SMTP/IMAP readiness probes to MailKit clients, and fixed dispose order (cancel token → wait 500 ms → release port leases).

**PortLeaseManager**: Added OS-level port availability check to prevent leasing ports already occupied by other OS processes. Increased readiness probe timeout to 30 s.

Also integrates Renovate dependency updates: Browsers v151, Atata 3.11.0 → 3.12.0, Chrome for Testing .NET v151 patch.