### PR TITLE
OSOE-1311: Update browsers and dependencies: Firefox v154, Chrome 152.0.7977.54, Edge 151.0.4129.93

### DIFF
--- a/Lombiq.Tests.UI.Shortcuts/Lombiq.Tests.UI.Shortcuts.csproj
+++ b/Lombiq.Tests.UI.Shortcuts/Lombiq.Tests.UI.Shortcuts.csproj
@@ -17,7 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.10" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.11" />
     <!-- Microsoft.OpenApi is required by Microsoft.AspNetCore.OpenApi, but its default version has a security vulnerability.
          Note: Staying on the 2.x line intentionally (upgraded to the latest patched 2.x release). Microsoft.OpenApi 3.x is
          only supported starting with Microsoft.AspNetCore.OpenApi 11.x (ASP.NET Core 11, still in preview); using it here

--- a/Lombiq.Tests.UI/Extensions/ElementRetrievalUITestContextExtensions.cs
+++ b/Lombiq.Tests.UI/Extensions/ElementRetrievalUITestContextExtensions.cs
@@ -1,11 +1,11 @@
 using Atata;
-using Lombiq.HelpfulLibraries.Common.Utilities;
 using Lombiq.Tests.UI.Services;
 using OpenQA.Selenium;
 using Shouldly;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Globalization;
 using System.Linq;
 
 namespace Lombiq.Tests.UI.Extensions;
@@ -148,7 +148,10 @@ public static class ElementRetrievalUITestContextExtensions
             .Where(index => index >= 0)
             .ToList();
         var target = toMatch
-            .Select(item => item == null ? null : StringHelper.CreateInvariant($"{item}"))
+            // MA0185 doesn't apply: item is an arbitrary object that can hold culture-sensitive data at runtime.
+#pragma warning disable MA0185
+            .Select(item => item == null ? null : string.Create(CultureInfo.InvariantCulture, $"{item}"))
+#pragma warning restore MA0185
             .Select(item => item?.Trim())
             .ToArray();
 

--- a/Lombiq.Tests.UI/Extensions/FormUITestContextExtensions.cs
+++ b/Lombiq.Tests.UI/Extensions/FormUITestContextExtensions.cs
@@ -322,7 +322,10 @@ public static class FormUITestContextExtensions
     /// </summary>
     public static void SetDatePicker(this UITestContext context, string id, DateTime value) =>
         context.ExecuteScript(
+            // False positive, see https://github.com/meziantou/Meziantou.Analyzer/issues/1316. Remove once fixed.
+#pragma warning disable MA0075
             StringHelper.CreateInvariant($"document.getElementById('{id}').value = '{value:yyyy-MM-dd}';") +
+#pragma warning restore MA0075
             $"document.getElementById('{id}').dispatchEvent(new Event('change'));");
 
     public static DateTime GetDatePicker(this UITestContext context, string id) =>

--- a/Lombiq.Tests.UI/Extensions/FormUITestContextExtensions.cs
+++ b/Lombiq.Tests.UI/Extensions/FormUITestContextExtensions.cs
@@ -1,6 +1,5 @@
 using AngleSharp.Text;
 using Atata;
-using Lombiq.HelpfulLibraries.Common.Utilities;
 using Lombiq.Tests.UI.Helpers;
 using Lombiq.Tests.UI.Services;
 using OpenQA.Selenium;
@@ -60,7 +59,7 @@ public static class FormUITestContextExtensions
         var editorBy = by.Then(By.CssSelector(".trumbowyg-box > .trumbowyg-editor"));
         context.Get(editorBy).Click();
 
-        expectedHtml ??= StringHelper.CreateInvariant($"<p>{text}</p>");
+        expectedHtml ??= $"<p>{text}</p>";
 
         return context.ExecuteLoggedAsync(
             nameof(ClickAndFillInTrumbowygEditorWithRetriesAsync),
@@ -322,10 +321,7 @@ public static class FormUITestContextExtensions
     /// </summary>
     public static void SetDatePicker(this UITestContext context, string id, DateTime value) =>
         context.ExecuteScript(
-            // False positive, see https://github.com/meziantou/Meziantou.Analyzer/issues/1316. Remove once fixed.
-#pragma warning disable MA0075
-            StringHelper.CreateInvariant($"document.getElementById('{id}').value = '{value:yyyy-MM-dd}';") +
-#pragma warning restore MA0075
+            string.Create(CultureInfo.InvariantCulture, $"document.getElementById('{id}').value = '{value:yyyy-MM-dd}';") +
             $"document.getElementById('{id}').dispatchEvent(new Event('change'));");
 
     public static DateTime GetDatePicker(this UITestContext context, string id) =>

--- a/Lombiq.Tests.UI/Extensions/SeleniumResponseCompletedEventExtensions.cs
+++ b/Lombiq.Tests.UI/Extensions/SeleniumResponseCompletedEventExtensions.cs
@@ -1,8 +1,8 @@
-using Lombiq.HelpfulLibraries.Common.Utilities;
 using Lombiq.Tests.UI.Services;
 using OpenQA.Selenium.BiDi.Network;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Net;
 
@@ -14,18 +14,16 @@ public static class SeleniumResponseCompletedEventExtensions
         string.Join(Environment.NewLine, responses.Select(ToFormattedString));
 
     public static string ToFormattedString(this ResponseData response) =>
-         // False positive, see https://github.com/meziantou/Meziantou.Analyzer/issues/1316. Remove once fixed.
-#pragma warning disable MA0075, MA0076
-         StringHelper.CreateInvariant(
-             $"URL: {response.Url}{Environment.NewLine}" +
-             $"Status: {response.Status}{Environment.NewLine}" +
-             $"Headers: {string.Join(", ", response.Headers.Select(header => $"{header.Name}: {header.Value}"))}{Environment.NewLine}" +
-             $"Mime type: {response.MimeType}{Environment.NewLine}" +
-             $"Bytes received: {response.BytesReceived}{Environment.NewLine}" +
-             $"Headers size: {response.HeadersSize}{Environment.NewLine}" +
-             $"Body size: {response.BodySize}{Environment.NewLine}" +
-             $"Response content: {response.Content} {Environment.NewLine}");
-#pragma warning restore MA0075, MA0076
+        string.Create(
+            CultureInfo.InvariantCulture,
+            $"URL: {response.Url}{Environment.NewLine}" +
+            $"Status: {response.Status}{Environment.NewLine}" +
+            $"Headers: {string.Join(", ", response.Headers.Select(header => $"{header.Name}: {header.Value}"))}{Environment.NewLine}" +
+            $"Mime type: {response.MimeType}{Environment.NewLine}" +
+            $"Bytes received: {response.BytesReceived}{Environment.NewLine}" +
+            $"Headers size: {response.HeadersSize}{Environment.NewLine}" +
+            $"Body size: {response.BodySize}{Environment.NewLine}" +
+            $"Response content: {response.Content} {Environment.NewLine}");
 
     public static void WithIgnoreExpectedNotFoundResponseFilter(
         this OrchardCoreUITestExecutorConfiguration configuration,

--- a/Lombiq.Tests.UI/Extensions/SeleniumResponseCompletedEventExtensions.cs
+++ b/Lombiq.Tests.UI/Extensions/SeleniumResponseCompletedEventExtensions.cs
@@ -14,6 +14,8 @@ public static class SeleniumResponseCompletedEventExtensions
         string.Join(Environment.NewLine, responses.Select(ToFormattedString));
 
     public static string ToFormattedString(this ResponseData response) =>
+         // False positive, see https://github.com/meziantou/Meziantou.Analyzer/issues/1316. Remove once fixed.
+#pragma warning disable MA0075, MA0076
          StringHelper.CreateInvariant(
              $"URL: {response.Url}{Environment.NewLine}" +
              $"Status: {response.Status}{Environment.NewLine}" +
@@ -23,6 +25,7 @@ public static class SeleniumResponseCompletedEventExtensions
              $"Headers size: {response.HeadersSize}{Environment.NewLine}" +
              $"Body size: {response.BodySize}{Environment.NewLine}" +
              $"Response content: {response.Content} {Environment.NewLine}");
+#pragma warning restore MA0075, MA0076
 
     public static void WithIgnoreExpectedNotFoundResponseFilter(
         this OrchardCoreUITestExecutorConfiguration configuration,

--- a/Lombiq.Tests.UI/Extensions/VisualVerificationUITestContextExtensions.cs
+++ b/Lombiq.Tests.UI/Extensions/VisualVerificationUITestContextExtensions.cs
@@ -1,5 +1,4 @@
 using Codeuctivity.ImageSharpCompare;
-using Lombiq.HelpfulLibraries.Common.Utilities;
 using Lombiq.Tests.UI.Attributes;
 using Lombiq.Tests.UI.Constants;
 using Lombiq.Tests.UI.Exceptions;
@@ -74,7 +73,7 @@ to customize the name of the dump item.";
                     pixelErrorPercentageThreshold: pixelErrorPercentageThreshold,
                     configurator: configuration =>
                     {
-                        configuration.WithFileNameSuffix(StringHelper.CreateInvariant($"{size.Width}x{size.Height}"));
+                        configuration.WithFileNameSuffix(string.Create(CultureInfo.InvariantCulture, $"{size.Width}x{size.Height}"));
                         configurator?.Invoke(configuration);
                     });
             }

--- a/Lombiq.Tests.UI/Helpers/ReliabilityHelper.cs
+++ b/Lombiq.Tests.UI/Helpers/ReliabilityHelper.cs
@@ -1,5 +1,4 @@
 using Atata;
-using Lombiq.HelpfulLibraries.Common.Utilities;
 using OpenQA.Selenium;
 using OpenQA.Selenium.Support.UI;
 using System;
@@ -334,8 +333,8 @@ public static class ReliabilityHelper
     {
         if (retriesResult.IsSuccess) return;
 
-        throw new TimeoutException(StringHelper.CreateInvariant(
+        throw new TimeoutException(
             $"The process didn't succeed with retries before timing out (timeout: {retriesResult.Wait.Timeout}, " +
-            $"polling interval: {retriesResult.Wait.PollingInterval}."));
+            $"polling interval: {retriesResult.Wait.PollingInterval}.");
     }
 }

--- a/Lombiq.Tests.UI/Lombiq.Tests.UI.csproj
+++ b/Lombiq.Tests.UI/Lombiq.Tests.UI.csproj
@@ -53,12 +53,12 @@
     <PackageReference Include="OrchardCore.Logging.NLog" Version="$(OrchardCoreVersion)" />
     <PackageReference Include="OrchardCore.Recipes.Core" Version="$(OrchardCoreVersion)" />
     <PackageReference Include="OrchardCore.Workflows" Version="$(OrchardCoreVersion)" />
-    <PackageReference Include="Sarif.Sdk" Version="5.5.0" />
+    <PackageReference Include="Sarif.Sdk" Version="5.6.0" />
     <PackageReference Include="YamlDotNet" Version="18.1.0" />
     <!-- Microsoft.AspNetCore.DataProtection transitively pulls in System.Security.Cryptography.Xml 10.0.8, which has
          a known high severity vulnerability (CVE-2026-47304); pin to the patched version. This can be removed once
          Microsoft.AspNetCore.DataProtection is updated. -->
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.10" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.11" />
   </ItemGroup>
   
 

--- a/Lombiq.Tests.UI/Models/BrowserLogEntry.cs
+++ b/Lombiq.Tests.UI/Models/BrowserLogEntry.cs
@@ -1,9 +1,9 @@
-using Lombiq.HelpfulLibraries.Common.Utilities;
 using Lombiq.Tests.UI.Services;
 using OpenQA.Selenium.BiDi.Log;
 using OpenQA.Selenium.BiDi.Script;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 
 namespace Lombiq.Tests.UI.Models;
@@ -21,7 +21,7 @@ public record BrowserLogEntry(
     }
 
     public string ToFormattedString() =>
-        StringHelper.CreateInvariant($"{Timestamp:yyyy-MM-dd HH:mm:ss} {Level} {Text}{FormatStackTrace(StackTrace)}");
+        string.Create(CultureInfo.InvariantCulture, $"{Timestamp:yyyy-MM-dd HH:mm:ss} {Level} {Text}{FormatStackTrace(StackTrace)}");
 
     public bool IsNonSuccessBrowserLogEntry() =>
         OrchardCoreUITestExecutorConfiguration.IsNonSuccessBrowserLogEntry(this);
@@ -39,11 +39,7 @@ public record BrowserLogEntry(
                 stackTrace.CallFrames.Select(frame =>
                     "- " +
                     (string.IsNullOrEmpty(frame.FunctionName) ? string.Empty : $"{frame.FunctionName} at ") +
-                    // False positive, see https://github.com/meziantou/Meziantou.Analyzer/issues/1316. Remove once
-                    // fixed.
-#pragma warning disable MA0075
-                    StringHelper.CreateInvariant($"{frame.Url}:{frame.LineNumber}:{frame.ColumnNumber}")));
-#pragma warning restore MA0075
+                    string.Create(CultureInfo.InvariantCulture, $"{frame.Url}:{frame.LineNumber}:{frame.ColumnNumber}")));
     }
 }
 

--- a/Lombiq.Tests.UI/Models/BrowserLogEntry.cs
+++ b/Lombiq.Tests.UI/Models/BrowserLogEntry.cs
@@ -39,7 +39,11 @@ public record BrowserLogEntry(
                 stackTrace.CallFrames.Select(frame =>
                     "- " +
                     (string.IsNullOrEmpty(frame.FunctionName) ? string.Empty : $"{frame.FunctionName} at ") +
+                    // False positive, see https://github.com/meziantou/Meziantou.Analyzer/issues/1316. Remove once
+                    // fixed.
+#pragma warning disable MA0075
                     StringHelper.CreateInvariant($"{frame.Url}:{frame.LineNumber}:{frame.ColumnNumber}")));
+#pragma warning restore MA0075
     }
 }
 

--- a/Lombiq.Tests.UI/Models/FakeLoggerLogApplicationLog.cs
+++ b/Lombiq.Tests.UI/Models/FakeLoggerLogApplicationLog.cs
@@ -41,6 +41,9 @@ public record FakeLoggerApplicationLogEntry(FakeLogRecord LogRecord) : IApplicat
     public override string ToString() => FormatLogRecord(LogRecord);
 
     public static string FormatLogRecord(FakeLogRecord record) =>
+        // False positive, see https://github.com/meziantou/Meziantou.Analyzer/issues/1316. Remove once fixed.
+#pragma warning disable MA0075
         StringHelper.CreateInvariant($"{record.Timestamp:yyyy-MM-dd HH:mm:ss.fff} [{record.Level}] {record.Category}: {record.Message}") +
+#pragma warning restore MA0075
         (record.Exception != null ? record.Exception.ToString() : string.Empty);
 }

--- a/Lombiq.Tests.UI/Models/FakeLoggerLogApplicationLog.cs
+++ b/Lombiq.Tests.UI/Models/FakeLoggerLogApplicationLog.cs
@@ -1,9 +1,9 @@
-using Lombiq.HelpfulLibraries.Common.Utilities;
 using Lombiq.Tests.UI.Services;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Testing;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -41,9 +41,8 @@ public record FakeLoggerApplicationLogEntry(FakeLogRecord LogRecord) : IApplicat
     public override string ToString() => FormatLogRecord(LogRecord);
 
     public static string FormatLogRecord(FakeLogRecord record) =>
-        // False positive, see https://github.com/meziantou/Meziantou.Analyzer/issues/1316. Remove once fixed.
-#pragma warning disable MA0075
-        StringHelper.CreateInvariant($"{record.Timestamp:yyyy-MM-dd HH:mm:ss.fff} [{record.Level}] {record.Category}: {record.Message}") +
-#pragma warning restore MA0075
+        string.Create(
+            CultureInfo.InvariantCulture,
+            $"{record.Timestamp:yyyy-MM-dd HH:mm:ss.fff} [{record.Level}] {record.Category}: {record.Message}") +
         (record.Exception != null ? record.Exception.ToString() : string.Empty);
 }

--- a/Lombiq.Tests.UI/Models/InstanceCommandLineArgs.cs
+++ b/Lombiq.Tests.UI/Models/InstanceCommandLineArgs.cs
@@ -1,5 +1,5 @@
-using Lombiq.HelpfulLibraries.Common.Utilities;
 using System.Collections.Generic;
+using System.Globalization;
 
 namespace Lombiq.Tests.UI.Models;
 
@@ -18,7 +18,10 @@ public class InstanceCommandLineArgumentsBuilder
 
     public InstanceCommandLineArgumentsBuilder AddWithValue<T>(string key, T value)
     {
-        _arguments.Add(StringHelper.CreateInvariant($"{PrepareArg(key)}={value}"));
+        // MA0185 doesn't apply: value can be a culture-sensitive type (e.g. number, date) at runtime.
+#pragma warning disable MA0185
+        _arguments.Add(string.Create(CultureInfo.InvariantCulture, $"{PrepareArg(key)}={value}"));
+#pragma warning restore MA0185
 
         return this;
     }

--- a/Lombiq.Tests.UI/Services/FrontendServer.cs
+++ b/Lombiq.Tests.UI/Services/FrontendServer.cs
@@ -1,11 +1,11 @@
 #nullable enable
 
 using CliWrap;
-using Lombiq.HelpfulLibraries.Common.Utilities;
 using Lombiq.Tests.UI.Extensions;
 using Lombiq.Tests.UI.Models;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
@@ -166,7 +166,7 @@ public class FrontendServer
         _configuration.CustomConfiguration.GetMaybe(GetKey(orchardPort)) as FrontendServerContext;
 
     private string GetKey(int orchardPort) =>
-        StringHelper.CreateInvariant($"{nameof(FrontendServer)}:{Name}:{orchardPort}");
+        string.Create(CultureInfo.InvariantCulture, $"{nameof(FrontendServer)}:{Name}:{orchardPort}");
 
     private static async Task WaitForStartupAsync(Task mainTask, Task waitTask, TimeSpan? timeout)
     {
@@ -184,7 +184,8 @@ public class FrontendServer
 
         if (timeoutTask?.IsCompleted == true)
         {
-            throw new TimeoutException(StringHelper.CreateInvariant(
+            throw new TimeoutException(string.Create(
+                CultureInfo.InvariantCulture,
                 $"The timeout of {nameof(FrontendServer)} ({timeout}) is exceeded."));
         }
     }

--- a/Lombiq.Tests.UI/Services/GitHub/GitHubAnnotationWriter.cs
+++ b/Lombiq.Tests.UI/Services/GitHub/GitHubAnnotationWriter.cs
@@ -1,9 +1,9 @@
 #nullable enable
 
-using Lombiq.HelpfulLibraries.Common.Utilities;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Diagnostics;
+using System.Globalization;
 using System.Linq;
 using Xunit;
 using Xunit.Sdk;
@@ -46,7 +46,7 @@ public class GitHubAnnotationWriter
         // in a submodule) then the annotation will not display at all.
         if (!string.IsNullOrWhiteSpace(file))
         {
-            message = StringHelper.CreateInvariant($"(file={file},line={line}) {message}");
+            message = string.Create(CultureInfo.InvariantCulture, $"(file={file},line={line}) {message}");
         }
 
         _testOutputHelper.WriteLine($"::{command} title={title}::{message}");

--- a/Lombiq.Tests.UI/Services/OrchardCoreInstance.cs
+++ b/Lombiq.Tests.UI/Services/OrchardCoreInstance.cs
@@ -1,4 +1,3 @@
-using Lombiq.HelpfulLibraries.Common.Utilities;
 using Lombiq.Tests.Integration.Services;
 using Lombiq.Tests.UI.Helpers;
 using Lombiq.Tests.UI.Models;
@@ -12,6 +11,7 @@ using Microsoft.Extensions.Logging.Testing;
 using Microsoft.VisualBasic.FileIO;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -45,7 +45,7 @@ internal static class OrchardCoreInstanceCounter
         PortLeases = new(9000 + agentIndexTimesHundred, 9099 + agentIndexTimesHundred);
     }
 
-    public static Uri GetUri(int port) => new(StringHelper.CreateInvariant($"https://localhost:{port}"));
+    public static Uri GetUri(int port) => new(string.Create(CultureInfo.InvariantCulture, $"https://localhost:{port}"));
     public static async Task<Uri> GetNewUriAsync() => GetUri(await PortLeases.LeaseAvailableRandomPortAsync(CancellationToken.None));
 }
 

--- a/Lombiq.Tests.UI/Services/WebDriverFactory.cs
+++ b/Lombiq.Tests.UI/Services/WebDriverFactory.cs
@@ -37,7 +37,7 @@ public static class WebDriverFactory
             // is updated automatically by Renovate.
             // If anything on this line is changed, be sure to adjust the regex in the renovate.json5 config file in the
             // root too.
-            chromeConfig.Options.BrowserVersion = "152.0.7977.42";
+            chromeConfig.Options.BrowserVersion = "152.0.7977.54";
 
             configuration.BrowserOptionsConfigurator?.Invoke(chromeConfig.Options);
 
@@ -68,17 +68,17 @@ public static class WebDriverFactory
             // root too.
             if (OperatingSystem.IsLinux())
             {
-                var linuxEdgeVersion = "151.0.4129.78";
+                var linuxEdgeVersion = "151.0.4129.93";
                 options.BrowserVersion = linuxEdgeVersion;
             }
             else if (OperatingSystem.IsWindows())
             {
-                var windowsEdgeVersion = "151.0.4129.78";
+                var windowsEdgeVersion = "151.0.4129.93";
                 options.BrowserVersion = windowsEdgeVersion;
             }
             else if (!OperatingSystem.IsMacOS())
             {
-                var macOsEdgeVersion = "151.0.4129.78";
+                var macOsEdgeVersion = "151.0.4129.93";
                 options.BrowserVersion = macOsEdgeVersion;
             }
 

--- a/Lombiq.Tests.UI/Services/WebDriverFactory.cs
+++ b/Lombiq.Tests.UI/Services/WebDriverFactory.cs
@@ -118,7 +118,7 @@ public static class WebDriverFactory
             // automatically by Renovate.
             // If anything on this line is changed, be sure to adjust the regex in the renovate.json5 config file in the
             // root too.
-            firefoxOptions.BrowserVersion = "153.0";
+            firefoxOptions.BrowserVersion = "154.0";
 
             if (configuration.Headless) firefoxOptions.AddArgument("--headless");
 


### PR DESCRIPTION
Renovate dependency integration for OSOE-1311.

- Merged `renovate/major-browsers` (Firefox 153.0 -> 154.0), `renovate/non-breaking-dependency-versions`, and `renovate/browsers` (Chrome 152.0.7977.42 -> .54, Edge 151.0.4129.78 -> .93).
- Replaced `StringHelper.CreateInvariant` with `string.Create(CultureInfo.InvariantCulture, ...)`, since the former doesn't actually apply the invariant culture to interpolation holes; see https://github.com/meziantou/Meziantou.Analyzer/issues/1316#issuecomment-5363658245.
