### PR TITLE
OSOE-1312: Update dependencies: browsers (Chrome, Edge, Firefox), Azure.Storage.Blobs, Microsoft.SqlServer.SqlManagementObjects, Microsoft.OpenApi, Microsoft.Extensions.Diagnostics.Testing, Deque.AxeCore.Selenium

### DIFF
--- a/Lombiq.Tests.UI.Shortcuts/Lombiq.Tests.UI.Shortcuts.csproj
+++ b/Lombiq.Tests.UI.Shortcuts/Lombiq.Tests.UI.Shortcuts.csproj
@@ -27,7 +27,7 @@
          Microsoft.OpenApi >=3.0.0 (i.e., once it targets ASP.NET Core 11+ as stable), this direct PackageReference can be
          removed and the transitive version will be safe by default.
          Once this reference is removed, also remove the corresponding config from renovate.json5. -->
-    <PackageReference Include="Microsoft.OpenApi" Version="2.11.0" />
+    <PackageReference Include="Microsoft.OpenApi" Version="2.12.0" />
     <PackageReference Include="OrchardCore.Users" Version="$(OrchardCoreVersion)" />
   </ItemGroup>
 

--- a/Lombiq.Tests.UI/Lombiq.Tests.UI.csproj
+++ b/Lombiq.Tests.UI/Lombiq.Tests.UI.csproj
@@ -44,7 +44,7 @@
     <PackageReference Include="Azure.Storage.Blobs" Version="12.29.1" />
     <PackageReference Include="Ben.Demystifier" Version="0.4.1" />
     <PackageReference Include="Codeuctivity.ImageSharpCompare" Version="4.1.390" />
-    <PackageReference Include="Deque.AxeCore.Selenium" Version="4.12.0" />
+    <PackageReference Include="Deque.AxeCore.Selenium" Version="4.13.0" />
     <PackageReference Include="MailKit" Version="4.17.0" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.Testing" Version="10.8.0" />
     <PackageReference Include="Microsoft.SqlServer.DACFx" Version="170.4.83" />

--- a/Lombiq.Tests.UI/Lombiq.Tests.UI.csproj
+++ b/Lombiq.Tests.UI/Lombiq.Tests.UI.csproj
@@ -46,7 +46,7 @@
     <PackageReference Include="Codeuctivity.ImageSharpCompare" Version="4.1.390" />
     <PackageReference Include="Deque.AxeCore.Selenium" Version="4.12.0" />
     <PackageReference Include="MailKit" Version="4.17.0" />
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.Testing" Version="10.8.0" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.Testing" Version="10.9.0" />
     <PackageReference Include="Microsoft.SqlServer.DACFx" Version="170.4.83" />
     <PackageReference Include="Microsoft.SqlServer.SqlManagementObjects" Version="181.25.0" />
     <PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0" />

--- a/Lombiq.Tests.UI/Lombiq.Tests.UI.csproj
+++ b/Lombiq.Tests.UI/Lombiq.Tests.UI.csproj
@@ -41,14 +41,14 @@
     <PackageReference Include="Atata.Bootstrap" Version="3.1.0" />
     <PackageReference Include="Atata.HtmlValidation" Version="3.5.0" />
     <PackageReference Include="Atata.WebDriverExtras" Version="3.8.0" />
-    <PackageReference Include="Azure.Storage.Blobs" Version="12.29.1" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.29.2" />
     <PackageReference Include="Ben.Demystifier" Version="0.4.1" />
     <PackageReference Include="Codeuctivity.ImageSharpCompare" Version="4.1.390" />
     <PackageReference Include="Deque.AxeCore.Selenium" Version="4.12.0" />
     <PackageReference Include="MailKit" Version="4.17.0" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.Testing" Version="10.8.0" />
     <PackageReference Include="Microsoft.SqlServer.DACFx" Version="170.4.83" />
-    <PackageReference Include="Microsoft.SqlServer.SqlManagementObjects" Version="181.25.0" />
+    <PackageReference Include="Microsoft.SqlServer.SqlManagementObjects" Version="181.36.0" />
     <PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0" />
     <PackageReference Include="OrchardCore.Logging.NLog" Version="$(OrchardCoreVersion)" />
     <PackageReference Include="OrchardCore.Recipes.Core" Version="$(OrchardCoreVersion)" />

--- a/Lombiq.Tests.UI/Services/WebDriverFactory.cs
+++ b/Lombiq.Tests.UI/Services/WebDriverFactory.cs
@@ -68,12 +68,12 @@ public static class WebDriverFactory
             // root too.
             if (OperatingSystem.IsLinux())
             {
-                var linuxEdgeVersion = "151.0.4129.93";
+                var linuxEdgeVersion = "152.0.4191.62";
                 options.BrowserVersion = linuxEdgeVersion;
             }
             else if (OperatingSystem.IsWindows())
             {
-                var windowsEdgeVersion = "151.0.4129.93";
+                var windowsEdgeVersion = "152.0.4191.62";
                 options.BrowserVersion = windowsEdgeVersion;
             }
             else if (!OperatingSystem.IsMacOS())
@@ -118,7 +118,7 @@ public static class WebDriverFactory
             // automatically by Renovate.
             // If anything on this line is changed, be sure to adjust the regex in the renovate.json5 config file in the
             // root too.
-            firefoxOptions.BrowserVersion = "154.0";
+            firefoxOptions.BrowserVersion = "155.0";
 
             if (configuration.Headless) firefoxOptions.AddArgument("--headless");
 

--- a/Lombiq.Tests.UI/Services/WebDriverFactory.cs
+++ b/Lombiq.Tests.UI/Services/WebDriverFactory.cs
@@ -37,7 +37,7 @@ public static class WebDriverFactory
             // is updated automatically by Renovate.
             // If anything on this line is changed, be sure to adjust the regex in the renovate.json5 config file in the
             // root too.
-            chromeConfig.Options.BrowserVersion = "152.0.7977.54";
+            chromeConfig.Options.BrowserVersion = "152.0.7977.82";
 
             configuration.BrowserOptionsConfigurator?.Invoke(chromeConfig.Options);
 


### PR DESCRIPTION
Part of [OSOE-1312](https://lombiq.atlassian.net/browse/OSOE-1312).

Merges:
- #809 `renovate/browsers` — Chrome for Testing .NET 152.0.7977.54 → 152.0.7977.82.
- #818 `renovate/major-browsers` — Edge 151.0.4129.93 → 152.0.4191.62, Firefox 154.0 → 155.0.
- #817 `renovate/non-breaking-dependency-versions` — Azure.Storage.Blobs 12.29.1 → 12.29.2, Microsoft.SqlServer.SqlManagementObjects 181.25.0 → 181.36.0, Microsoft.OpenApi 2.11.0 → 2.12.0.
- #815 `renovate/microsoft.extensions` — Microsoft.Extensions.Diagnostics.Testing 10.8.0 → 10.9.0.
- #814 `renovate/deque.axecore` — Deque.AxeCore.Selenium 4.12.0 → 4.13.0.


[OSOE-1312]: https://lombiq.atlassian.net/browse/OSOE-1312?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ