### PR TITLE
OSOE-1312: Update dependencies: Microsoft.OpenApi 2.12.2

### DIFF
--- a/Lombiq.Tests.UI.Shortcuts/Lombiq.Tests.UI.Shortcuts.csproj
+++ b/Lombiq.Tests.UI.Shortcuts/Lombiq.Tests.UI.Shortcuts.csproj
@@ -27,7 +27,7 @@
          Microsoft.OpenApi >=3.0.0 (i.e., once it targets ASP.NET Core 11+ as stable), this direct PackageReference can be
          removed and the transitive version will be safe by default.
          Once this reference is removed, also remove the corresponding config from renovate.json5. -->
-    <PackageReference Include="Microsoft.OpenApi" Version="2.12.0" />
+    <PackageReference Include="Microsoft.OpenApi" Version="2.12.2" />
     <PackageReference Include="OrchardCore.Users" Version="$(OrchardCoreVersion)" />
   </ItemGroup>
 


### PR DESCRIPTION
Part of [OSOE-1312](https://lombiq.atlassian.net/browse/OSOE-1312) (follow-up).

Merges:
- #817 `renovate/non-breaking-dependency-versions` — Microsoft.OpenApi → 2.12.2.

Renovate rewrote this rolling branch with new content (2.12.1, then 2.12.2) after the original PR of the same name had already been merged as part of [OSOE-1312](https://lombiq.atlassian.net/browse/OSOE-1312)'s first round. PR #818 (major-browsers) was auto-closed by Renovate in the meantime and needs no further action.


[OSOE-1312]: https://lombiq.atlassian.net/browse/OSOE-1312?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OSOE-1312]: https://lombiq.atlassian.net/browse/OSOE-1312?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ