### PR TITLE
NEST-671: Added the ability to carry the By into ClickReliablyAsync and refresh the element

### DIFF
--- a/Lombiq.Tests.UI/BasicOrchardFeaturesTesting/BasicFeaturesTestingUITestContextExtensions.cs
+++ b/Lombiq.Tests.UI/BasicOrchardFeaturesTesting/BasicFeaturesTestingUITestContextExtensions.cs
@@ -576,11 +576,13 @@ public static class BasicFeaturesTestingUITestContextExtensions
             "Test turning feature on and off",
             async () =>
             {
+                var byFeatureIds = By.Name("featureIds");
+
                 async Task<IWebElement> SearchForFeatureAsync(UITestContext context)
                 {
                     await context.GoToFeaturesAsync();
                     await context.ClickAndFillInWithRetriesAsync(By.Id("search-box"), featureName);
-                    return context.Get(By.Name("featureIds"));
+                    return context.Get(byFeatureIds);
                 }
 
                 var feature = await SearchForFeatureAsync(context);
@@ -590,7 +592,7 @@ public static class BasicFeaturesTestingUITestContextExtensions
                 for (var i = 0; i < 2; i++)
                 {
                     feature = await SearchForFeatureAsync(context);
-                    await feature.ClickReliablyAsync(context);
+                    await feature.ClickReliablyAsync(context, byFeatureIds);
                     await context.BulkActionsToggleAsync();
 
                     targetState = !targetState;

--- a/Lombiq.Tests.UI/BasicOrchardFeaturesTesting/MediaOperationsTestingUITestContextExtensions.cs
+++ b/Lombiq.Tests.UI/BasicOrchardFeaturesTesting/MediaOperationsTestingUITestContextExtensions.cs
@@ -35,9 +35,9 @@ public static class MediaOperationsTestingUITestContextExtensions
                 context.Missing(By.CssSelector("#mediaContainerMain .upload-list .text-danger"));
                 context.Exists(By.XPath($"//span[contains(text(), '{imageName}')]"));
 
-                await context
-                    .Get(By.CssSelector($"a[href^=\"{context.UrlPrefix}/media/{imageName}\"]").OfAnyVisibility())
-                    .ClickReliablyAsync(context);
+                await context.ClickReliablyOnAsync(
+                    By.CssSelector($"a[href^=\"{context.UrlPrefix}/media/{imageName}\"]").OfAnyVisibility());
+
                 // Closing the newly opened tab with the image, so the browser doesn't continue to switch the UI back
                 // and forth.
                 context.DoWithRetriesOrFail(
@@ -60,16 +60,13 @@ public static class MediaOperationsTestingUITestContextExtensions
                 // out). Thus not doing opening and closing it as with the image above.
                 context.Exists(By.XPath($"//span[contains(text(), '{documentName}')]"));
 
-                await context
-                    .Get(By.XPath($"//span[contains(text(), '{documentName}')]/ancestor::tr").OfAnyVisibility())
-                    .ClickReliablyAsync(context);
+                await context.ClickReliablyOnAsync(
+                    By.XPath($"//span[contains(text(), '{documentName}')]/ancestor::tr").OfAnyVisibility());
 
                 context.WaitForPageLoad();
                 await context.GoToAdminRelativeUrlAsync(mediaPath);
 
-                await context
-                    .Get(By.CssSelector("#folder-tree .treeroot .folder-actions"))
-                    .ClickReliablyAsync(context);
+                await context.ClickReliablyOnAsync(By.CssSelector("#folder-tree .treeroot .folder-actions"));
 
                 context.Get(By.Id("create-folder-name")).SendKeys("Example Folder");
 
@@ -86,16 +83,15 @@ public static class MediaOperationsTestingUITestContextExtensions
                 context.UploadSamplePdfByIdOfAnyVisibility("fileupload");
                 context.WaitForPageLoad();
 
-                var image = context.Get(By.XPath($"//span[contains(text(), '{imageName}')]"));
+                var byImage = ByHelper.TextContains(imageName, "span");
+                var image = context.Get(byImage);
 
                 context.Exists(By.XPath($"//span[contains(text(), '{documentName}')]"));
 
-                await image.ClickReliablyAsync(context);
+                await image.ClickReliablyAsync(context, byImage);
 
-                await context
-                    .Get(By.XPath($"//span[contains(text(), '{imageName}')]/ancestor::tr"))
-                    .Get(By.CssSelector("a.btn.btn-link.btn-sm.delete-button"))
-                    .ClickReliablyAsync(context);
+                await context.ClickReliablyOnAsync(
+                    By.XPath($"//span[contains(text(), '{imageName}')]/ancestor::tr//a[contains(@class, 'delete-button')]"));
 
                 await context.ClickModalOkAsync();
                 context.WaitForPageLoad();

--- a/Lombiq.Tests.UI/Extensions/FormUITestContextExtensions.cs
+++ b/Lombiq.Tests.UI/Extensions/FormUITestContextExtensions.cs
@@ -262,9 +262,10 @@ public static class FormUITestContextExtensions
 
     public static async Task SetCheckboxValueAsync(this UITestContext context, By by, bool isChecked = true)
     {
-        var element = context.Get(by.OfAnyVisibility());
+        by = by.OfAnyVisibility();
+        var element = context.Get(by);
         var currentValue = element.GetDomProperty("checked") == bool.TrueString;
-        if (currentValue != isChecked) await element.ClickReliablyAsync(context);
+        if (currentValue != isChecked) await element.ClickReliablyAsync(context, by);
     }
 
     public static int GetIntValue(this UITestContext context, By by) =>

--- a/Lombiq.Tests.UI/Extensions/NavigationUITestContextExtensions.cs
+++ b/Lombiq.Tests.UI/Extensions/NavigationUITestContextExtensions.cs
@@ -492,7 +492,7 @@ public static class NavigationUITestContextExtensions
     /// </summary>
     /// <param name="maxTries">The maximum number of clicks attempted altogether, if retries are needed.</param>
     public static Task ClickReliablyOnAsync(this UITestContext context, By by, int maxTries = 3) =>
-        context.Get(by).ClickReliablyAsync(context, maxTries);
+        context.Get(by).ClickReliablyAsync(context, by, maxTries);
 
     /// <summary>
     /// Reliably clicks on the link identified by the given text with <see
@@ -500,7 +500,7 @@ public static class NavigationUITestContextExtensions
     /// </summary>
     /// <param name="maxTries">The maximum number of clicks attempted altogether, if retries are needed.</param>
     public static Task ClickReliablyOnByLinkTextAsync(this UITestContext context, string linkText, int maxTries = 3) =>
-        context.Get(By.LinkText(linkText)).ClickReliablyAsync(context, maxTries);
+        context.ClickReliablyOnAsync(By.LinkText(linkText));
 
     /// <inheritdoc cref="ClickReliablyOnUntilNavigationHasOccurredAsync(UITestContext, By, TimeSpan?, TimeSpan?)"/>
     [Obsolete($"Use {nameof(ClickReliablyOnUntilNavigationHasOccurredAsync)} instead.")]

--- a/Lombiq.Tests.UI/Extensions/NavigationUITestContextExtensions.cs
+++ b/Lombiq.Tests.UI/Extensions/NavigationUITestContextExtensions.cs
@@ -552,7 +552,20 @@ public static class NavigationUITestContextExtensions
         TimeSpan? interval = null)
     {
         var currentUrl = context.Driver.Url;
-        await context.ClickReliablyOnAsync(by);
+
+        // If selected HTML element is <a> and it points to the current page, then this method will time out. To get
+        // around this problem, we modify the current URL using JavaScript.
+        var element = context.Get(by);
+        if (element.TagName == TagNames.A)
+        {
+            context.ExecuteScript(
+                "if (arguments[0].href === location.href) window.history.replaceState(null, '', `${location.href}#ts=${Date.now()}`);",
+                element);
+            currentUrl = context.Driver.Url;
+        }
+
+        await element.ClickReliablyAsync(context, by);
+
         ReliabilityHelper.DoWithRetriesOrFail(
             () => context.Driver.Url != currentUrl,
             timeout,

--- a/Lombiq.Tests.UI/Extensions/NavigationWebElementExtensions.cs
+++ b/Lombiq.Tests.UI/Extensions/NavigationWebElementExtensions.cs
@@ -1,4 +1,5 @@
 using Atata;
+using Lombiq.Tests.UI.Models;
 using Lombiq.Tests.UI.Services;
 using OpenQA.Selenium;
 using System;
@@ -9,6 +10,9 @@ namespace Lombiq.Tests.UI.Extensions;
 
 public static class NavigationWebElementExtensions
 {
+    public static Task ClickReliablyAsync(this IWebElement element, UITestContext context, int maxTries = 3) =>
+        element.ClickReliablyAsync(context, originalSelector: null, maxTries);
+
     /// <summary>
     /// Clicks an element even if the default Click() will sometimes fail to do so. It's more reliable than Click() but
     /// still not perfect. If you're doing a Get() before then use <see
@@ -23,7 +27,7 @@ public static class NavigationWebElementExtensions
     /// </para>
     /// </remarks>
     /// <param name="maxTries">The maximum number of clicks attempted altogether, if retries are needed.</param>
-    public static Task ClickReliablyAsync(this IWebElement element, UITestContext context, int maxTries = 3) =>
+    public static Task ClickReliablyAsync(this IWebElement element, UITestContext context, By originalSelector, int maxTries = 3) =>
         context.ExecuteLoggedAsync(
             nameof(ClickReliablyAsync),
             element,
@@ -43,39 +47,13 @@ public static class NavigationWebElementExtensions
                         context.Driver.Perform(actions => actions.MoveToElement(element).Click());
                         notFound = false;
                     }
-                    catch (Exception ex) when (i < maxTries)
+                    catch (Exception exception) when (i < maxTries)
                     {
-                        switch (ex)
-                        {
-                            case MoveTargetOutOfBoundsException:
-                                context.ScrollTo(element.Location.X, element.Location.Y);
-                                break;
+                        var errorContext = HandleFailedClick(
+                            new ClickReliablyErrorContext(context, element, originalSelector, exception));
 
-                            case { } when ex.Message.Contains("move target out of bounds"):
-                                context.Configuration.TestOutputHelper.WriteLineTimestampedAndDebug(
-                                    "\"move target out of bounds\" exception, retrying the click.");
-                                break;
-
-                            case WebDriverException webDriverException when webDriverException.IsStaleElementLikeException():
-                                context.Configuration.TestOutputHelper.WriteLineTimestampedAndDebug(
-                                    "Stale element exception with the message \"{0}\", retrying the click.",
-                                    ex.Message);
-                                break;
-
-                            case { } when ex.Message.ContainsOrdinalIgnoreCase(
-                                "javascript error: Failed to execute 'elementsFromPoint' on 'Document': The provided double value is non-finite."):
-                                throw new NotSupportedException(
-                                    "For this element use the standard Click() method.");
-
-                            case UnknownErrorException when ex.Message.ContainsOrdinalIgnoreCase(
-                                "MarionetteCommands:MarionetteCommandsParent:_dispatchEvent: message reply cannot be cloned."):
-                                context.Configuration.TestOutputHelper.WriteLineTimestampedAndDebug(
-                                    "Problem with Marionette communication, retrying the click.");
-                                break;
-
-                            default:
-                                throw;
-                        }
+                        element = errorContext.Element;
+                        if (errorContext.ShouldThrow) throw;
 
                         await Task.Delay(RetrySettings.Interval, context.Configuration.TestCancellationToken);
                     }
@@ -84,6 +62,50 @@ public static class NavigationWebElementExtensions
                 await context.Configuration.Events.AfterClick
                     .InvokeAsync<ClickEventHandler>(eventHandler => eventHandler(context, element));
             });
+
+    /// <summary>
+    /// Handles exceptions in <see cref="ClickReliablyAsync(IWebElement, UITestContext, By, int)"/>.
+    /// </summary>
+    private static ClickReliablyErrorContext HandleFailedClick(ClickReliablyErrorContext errorContext)
+    {
+        var context = errorContext.Context;
+        var exception = errorContext.Exception;
+
+        switch (exception)
+        {
+            case MoveTargetOutOfBoundsException:
+                context.ScrollTo(errorContext.Element.Location.X, errorContext.Element.Location.Y);
+                return errorContext;
+
+            case { } when exception.Message.Contains("move target out of bounds"):
+                context.Configuration.TestOutputHelper.WriteLineTimestampedAndDebug(
+                    "\"move target out of bounds\" exception, retrying the click.");
+                return errorContext;
+
+            case WebDriverException webDriverException when webDriverException.IsStaleElementLikeException():
+                context.Configuration.TestOutputHelper.WriteLineTimestampedAndDebug(
+                    "Stale element exception with the message \"{0}\", retrying the click.",
+                    exception.Message);
+
+                return errorContext.OriginalSelector is { } by && context.Get(by.Safely()) is { } element
+                        ? errorContext with { Element = element }
+                        : errorContext;
+
+            case { } when exception.Message.ContainsOrdinalIgnoreCase(
+                "javascript error: Failed to execute 'elementsFromPoint' on 'Document': The provided double value is non-finite."):
+                throw new NotSupportedException(
+                    "For this element use the standard Click() method.");
+
+            case UnknownErrorException when exception.Message.ContainsOrdinalIgnoreCase(
+                "MarionetteCommands:MarionetteCommandsParent:_dispatchEvent: message reply cannot be cloned."):
+                context.Configuration.TestOutputHelper.WriteLineTimestampedAndDebug(
+                    "Problem with Marionette communication, retrying the click.");
+                return errorContext;
+
+            default:
+                return errorContext with { ShouldThrow = true };
+        }
+    }
 
     /// <inheritdoc cref="ClickReliablyUntilNavigationHasOccurredAsync(IWebElement, UITestContext, TimeSpan?, TimeSpan?)"/>
     [Obsolete("Use ClickReliablyUntilNavigationHasOccurredAsync instead.")]

--- a/Lombiq.Tests.UI/Models/ClickReliablyErrorContext.cs
+++ b/Lombiq.Tests.UI/Models/ClickReliablyErrorContext.cs
@@ -1,0 +1,14 @@
+#nullable enable
+
+using Lombiq.Tests.UI.Services;
+using OpenQA.Selenium;
+using System;
+
+namespace Lombiq.Tests.UI.Models;
+
+public record ClickReliablyErrorContext(
+    UITestContext Context,
+    IWebElement Element,
+    By? OriginalSelector,
+    Exception Exception,
+    bool ShouldThrow = false);


### PR DESCRIPTION
[NEST-671](https://lombiq.atlassian.net/browse/NEST-671)

[NEST-671]: https://lombiq.atlassian.net/browse/NEST-671?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ